### PR TITLE
WebServer reload using nodemon with appropriate file watchers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,22 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Chrome: Test Client Beta (Preact)",
-            "port": 9222,
+            "name": "[DEV]: Start Server (Google Chrome)",
+            "type": "chrome",
+            "url": "http://localhost:8080/testclient.html?~~localhost:8000",
             "request": "launch",
-            "url": "${config:showdown.clientUrl}/testclient-beta.html${config:showdown.server}",
-            "type": "pwa-chrome",
-            "webRoot": "${workspaceFolder}",
-            "preLaunchTask": "npm: build"
-        },
-        {
-            "name": "Chrome: Test Client",
-            "port": 9222,
-            "request": "launch",
-            "url": "${config:showdown.clientUrl}/testclient.html${config:showdown.server}",
-            "type": "pwa-chrome",
-            "webRoot": "${workspaceFolder}",
-            "preLaunchTask": "npm: build"
+            "preLaunchTask": "Start TSC Watcher",
+            "postDebugTask": "Terminate All Tasks",
+            "sourceMaps": true,
+            "sourceMapPathOverrides": {
+                "/data/*.ts": "${workspaceFolder}/src/*.ts",
+                "/*.ts": "${workspaceFolder}/src/*.ts",
+            }
         }
     ]
 } 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "editor.formatOnSave": false,
+  /// IMO This should be on by default. 
+  "editor.formatOnSave": true,
   "showdown.server": "", // e.g., "?~~localhost:8000"
   "showdown.clientUrl": "http://localhost:8080",
   "tslint.configFile": "tslint.json",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start TSC Watcher",
+            "script": "serve",
+            "type": "npm",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "custom",
+                "pattern": {
+                    "regexp": "^$"
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^.*[nodemon] starting.*",
+                    "endsPattern": "^.*Hit CTRL-C to stop the server.*"
+                }
+            }
+        },
+        {
+            "label": "Terminate All Tasks",
+            "command": "echo ${input:terminate}",
+            "type": "shell",
+            "problemMatcher": []
+        },
+    ],
+    "inputs": [
+        {
+          "id": "terminate",
+          "type": "command",
+          "command": "workbench.action.tasks.terminate",
+          "args": "terminateAll"
+        }
+      ]
+}

--- a/build_and_serve.js
+++ b/build_and_serve.js
@@ -1,20 +1,26 @@
 var { execSync, spawn } = require("child_process");
 
-execSync("npm run build");
+async function pipeOutput(child) {
+	return new Promise((res, rej) => {
+		//spit stdout to screen
+		child.stdout.on("data", function (data) {
+			process.stdout.write(data.toString());
+		});
 
-//kick off process of listing files
-var child = spawn("npx", ["http-server", "-c-1"], { shell: true });
+		//spit stderr to screen
+		child.stderr.on("data", function (data) {
+			process.stdout.write(data.toString());
+		});
 
-//spit stdout to screen
-child.stdout.on("data", function (data) {
-	process.stdout.write(data.toString());
-});
+		child.on("close", function (code) {
+			res(code);
+		});
+	});
+}
 
-//spit stderr to screen
-child.stderr.on("data", function (data) {
-	process.stdout.write(data.toString());
-});
+async function main() {
+	await pipeOutput(spawn("npm", ["run", "build"], { shell: true }));
+	await pipeOutput(spawn("npx", ["http-server", "-c-1"], { shell: true }));
+}
 
-child.on("close", function (code) {
-	console.log("Finished with code " + code);
-});
+main().then(() => process.exit(0));

--- a/build_and_serve.js
+++ b/build_and_serve.js
@@ -1,0 +1,20 @@
+var { execSync, spawn } = require("child_process");
+
+execSync("npm run build");
+
+//kick off process of listing files
+var child = spawn("npx", ["http-server", "-c-1"], { shell: true });
+
+//spit stdout to screen
+child.stdout.on("data", function (data) {
+	process.stdout.write(data.toString());
+});
+
+//spit stderr to screen
+child.stderr.on("data", function (data) {
+	process.stdout.write(data.toString());
+});
+
+child.on("close", function (code) {
+	console.log("Finished with code " + code);
+});

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -47,7 +47,7 @@
 				buf += '<p><label class="label" name="partner" style="display:none">';
 				buf += 'Partner: <input name="teammate" /></label></p>';
 				buf += '<p><label class="checkbox"><input type="checkbox" name="private" ' + (Storage.prefs('disallowspectators') ? 'checked' : '') + ' /> <abbr title="You can still invite spectators by giving them the URL or using the /invite command">Don\'t allow spectators</abbr></label></p>';
-				buf += '<p><button class="button mainmenu1 big" name="search"><strong>Battle!</strong><br /><small>Find a random opponent</small></button></p></form></div>';
+				buf += '<p><button class="button mainmenu1 big" name="search"><strong>Battle test change!</strong><br /><small>Find a random opponent</small></button></p></form></div>';
 			}
 
 			buf += '<div class="menugroup">';

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,17 +1,17 @@
 {
   "watch": ["src/", "js/"],
-  "ext": "js,ts",
+  "ext": "js,ts,css,html,json,tsx,jsx",
   "verbose": true,
   "ignore": [
     ".git",
     "node_modules/**/node_modules",
     "js/lib/**",
     "js/server/**",
-    "js/battle*",
-    "js/client-co*",
+    "js/battle*.js",
+    "js/client-co*.js",
     "js/client-main.js",
     "js/client-main.js.map",
-    "js/panel*",
+    "js/panel*.js",
     "js/replay-embed.js"
   ]
 }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,17 @@
+{
+  "watch": ["src/", "js/"],
+  "ext": "js,ts",
+  "verbose": true,
+  "ignore": [
+    ".git",
+    "node_modules/**/node_modules",
+    "js/lib/**",
+    "js/server/**",
+    "js/battle*",
+    "js/client-co*",
+    "js/client-main.js",
+    "js/client-main.js.map",
+    "js/panel*",
+    "js/replay-embed.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix": "eslint --config=.eslintrc.js --fix js/ && eslint --config=build-tools/.eslintrc.js --fix build-tools/update build-tools/build-indexes",
     "build": "node build && tsc",
     "build-full": "node build full",
-    "build-http": "node build && tsc --build --force && npx http-server"
+    "serve": "nodemon ./build_and_serve.js"
   },
   "dependencies": {
     "@babel/core": "^7.21.3",
@@ -32,8 +32,10 @@
     "@types/mocha": "^5.2.6",
     "eslint": "^5.16.0",
     "mocha": "^6.0.2",
+    "nodemon": "^3.1.4",
     "preact": "^8.3.1",
     "source-map": "^0.7.3",
+    "tsc-watch": "^6.2.0",
     "tslint": "^5.20.1",
     "typescript": "^4.9.5"
   },

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -1920,6 +1920,7 @@ export class PokemonSprite extends Sprite {
 	}
 
 	behindx(offset: number) {
+		console.debug("test");
 		return this.x + (this.isFrontSprite ? 1 : -1) * offset;
 	}
 	behindy(offset: number) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "lib": ["dom", "es6", "es2016.array.include", "es2017.object"],
+        "sourceMap": true,
         "noEmit": true,
         "target": "esnext",
         "module": "None",


### PR DESCRIPTION
The server will detect changes and compile/restart automatically, but you will still need to refresh your browser.

Run the new command via npm:
`npm run serve`

There is also a new VSCode Launch config called `[DEV]: Start Server (Google Chrome)`
This will first startup the http server as a terminal task, then launch an anonymous chrome browser with the correct url assuming you have your simulation server started (at localhost:8000).

Also supports debugging in VSCode for 90% of the codebase.
Unfortunately, a few files get compiled/mapped weirdly via `build-tools/compile`, specifically:

- src/battle-animations-moves.ts -> data/battle-animations-moves.ts
- src/battle-animations.ts -> data/battle-animations.ts

More may have weird handling that I didn't catch, but these are the files I know of for now.
Unfortunately, breakpoints in these files won't map properly to the chrome debugger and won't get hit via VSCode.
