### PR TITLE
Automated battle test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /audio/
-/config/
+/config/config.js
+/config/testclient-key.js
 /index.php
 /index.html
 /preactalpha.html

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,19 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "[DEV]: Singular Session (Chrome)",
+            "type": "chrome",
+            "url": "http://localhost:8080/testclient.html?~~localhost:8000",
+            "request": "launch",
+            "preLaunchTask": "Start TSC Watcher",
+            "postDebugTask": "Terminate All Tasks",
+            "sourceMaps": true,
+            "sourceMapPathOverrides": {
+                "/data/*.ts": "${workspaceFolder}/src/*.ts",
+                "/*.ts": "${workspaceFolder}/src/*.ts",
+            },
+        },
+        {
             "name": "[BROWSER] Player 1 Session",
             "request": "attach",
             "type": "chrome",
@@ -44,7 +57,6 @@
             "preLaunchTask": "Launch Browser Tabs",
             "postDebugTask": "Terminate All Tasks",
             "stopAll": true,
-            
         }
     ]
 } 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,50 @@
+/**
+* VSCode seems to limit an internal browser debugging session to one tab for the same url.
+* Unfortunately, that means it's not easy to create a native config that will launch two tabs.
+* To get around this, we use the node script start_browsers.js which runs chrome cli to spawn two tabs.
+* More information can be found inside the start_browsers.js script.
+*/
 {
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "[DEV]: Start Server (Google Chrome)",
+            "name": "[BROWSER] Player 1 Session",
+            "request": "attach",
             "type": "chrome",
-            "url": "http://localhost:8080/testclient.html?~~localhost:8000",
-            "request": "launch",
-            "preLaunchTask": "Start TSC Watcher",
+            "port": 9200,
+            "url": "http://localhost:8080/testclient.html?~~localhost:8000&username=${config:showdown.player1Name}",
+            "presentation": {
+                "hidden": true,
+                "group": "",
+                "order": 1
+            },
+            "suppressMultipleSessionWarning": true,
+        },
+        {
+            "name": "[BROWSER] Player 2 Session",
+            "request": "attach",
+            "type": "chrome",
+            "port": 9200,
+            "url": "http://localhost:8080/testclient.html?~~localhost:8000&username=${config:showdown.player2Name}",
+            "presentation": {
+                "hidden": true,
+                "group": "",
+                "order": 1
+            },
+            "suppressMultipleSessionWarning": true,
+        },
+    ],
+    "compounds": [
+        {
+            "name": "[DEV] Battle Debugging",
+            "configurations": [
+                "[BROWSER] Player 1 Session",
+                "[BROWSER] Player 2 Session"
+            ],
+            "preLaunchTask": "Launch Browser Tabs",
             "postDebugTask": "Terminate All Tasks",
-            "sourceMaps": true,
-            "sourceMapPathOverrides": {
-                "/data/*.ts": "${workspaceFolder}/src/*.ts",
-                "/*.ts": "${workspaceFolder}/src/*.ts",
-            }
+            "stopAll": true,
+            
         }
     ]
 } 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
   "editor.formatOnSave": true,
   "showdown.server": "", // e.g., "?~~localhost:8000"
   "showdown.clientUrl": "http://localhost:8080",
-  "showdown.player1Name": "user123456",
-  "showdown.player2Name": "user654321",
+  "showdown.player1Name": "player11112222",
+  "showdown.player2Name": "player88889999",
   "tslint.configFile": "tslint.json",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "editor.formatOnSave": true,
   "showdown.server": "", // e.g., "?~~localhost:8000"
   "showdown.clientUrl": "http://localhost:8080",
+  "showdown.player1Name": "user123456",
+  "showdown.player2Name": "user654321",
   "tslint.configFile": "tslint.json",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,25 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^.*[nodemon] starting.*",
-                    "endsPattern": "^.*Hit CTRL-C to stop the server.*"
+                    "endsPattern": "^.*Hit CTRL-C to stop the server.*",
+                }
+            }
+        },
+        {
+            "label": "Launch Browser Tabs",
+            "type": "shell",
+            "command": "node ${workspaceFolder}/start_browsers.js --user1 ${config:showdown.player1Name} --user2 ${config:showdown.player2Name}",
+            "dependsOn": "Start TSC Watcher",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "custom",
+                "pattern": {
+                    "regexp": "^$",
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "starting showdown browser tabs for two player battle testing",
+                    "endsPattern": "using chrome binary at",
                 }
             }
         },

--- a/build_and_serve.js
+++ b/build_and_serve.js
@@ -1,4 +1,4 @@
-var { execSync, spawn } = require("child_process");
+var { spawn } = require("child_process");
 
 async function pipeOutput(child) {
 	return new Promise((res, rej) => {

--- a/config/er-config.js
+++ b/config/er-config.js
@@ -1,0 +1,11 @@
+/**
+ * This file is intended to contain custom extra or overridden configs to the Elite Redux showdown port.
+ * Prefer leaving valid workable configs from standard pokemon showdown intact, referenced here: https://play.pokemonshowdown.com/config/config.js
+ */
+Config.devUsernameOverride = undefined;
+
+/// Determine if the client specified a username in the query string or not, and rename if they did.
+const usernameMatch = /username=([a-z0-9*]{1,19})/.exec(location.search);
+if (usernameMatch) {
+	Config.devUsernameOverride = usernameMatch[1];
+}

--- a/js/client.js
+++ b/js/client.js
@@ -1,54 +1,58 @@
 function toId() {
 	// toId has been renamed toID
-	alert("You have an old extension/script for Pokemon Showdown which is incompatible with this client. It needs to be removed or updated.");
+	alert(
+		"You have an old extension/script for Pokemon Showdown which is incompatible with this client. It needs to be removed or updated."
+	);
 }
 
 (function ($) {
-
-	Config.sockjsprefix = '/showdown';
-	Config.root = '/';
+	Config.sockjsprefix = "/showdown";
+	Config.root = "/";
 
 	if (window.nodewebkit) {
-		window.gui = require('nw.gui');
+		window.gui = require("nw.gui");
 		window.nwWindow = gui.Window.get();
 	}
 	if (navigator.userAgent.match(/(iPod|iPhone|iPad)/)) {
 		// Android mobile-web-app-capable doesn't support it very well, but iOS
 		// does it fine, so we're only going to show this to iOS for now
 		window.isiOS = true;
-		$('head').append('<meta name="apple-mobile-web-app-capable" content="yes" />');
+		$("head").append(
+			'<meta name="apple-mobile-web-app-capable" content="yes" />'
+		);
 	}
 
-	$(document).on('keydown', function (e) {
-		if (e.keyCode == 27) { // Esc
+	$(document).on("keydown", function (e) {
+		if (e.keyCode == 27) {
+			// Esc
 			e.preventDefault();
 			e.stopPropagation();
 			e.stopImmediatePropagation();
 			app.closePopup();
 		}
 	});
-	$(window).on('dragover', function (e) {
+	$(window).on("dragover", function (e) {
 		if (/^text/.test(e.target.type)) return; // Ignore text fields
 
 		e.preventDefault();
 	});
-	$(document).on('dragenter', function (e) {
+	$(document).on("dragenter", function (e) {
 		if (/^text/.test(e.target.type)) return; // Ignore text fields
 
 		e.preventDefault();
 
-		if (!app.dragging && app.curRoom.id === 'teambuilder') {
+		if (!app.dragging && app.curRoom.id === "teambuilder") {
 			var dataTransfer = e.originalEvent.dataTransfer;
 			if (dataTransfer.files && dataTransfer.files[0]) {
 				var file = dataTransfer.files[0];
-				if (file.name.slice(-4) === '.txt') {
+				if (file.name.slice(-4) === ".txt") {
 					// Someone dragged in a .txt file, hand it to the teambuilder
 					app.curRoom.defaultDragEnterTeam(e);
 				}
 			} else if (dataTransfer.items && dataTransfer.items[0]) {
 				// no files or no permission to access files
 				var item = dataTransfer.items[0];
-				if (item.kind === 'file' && item.type === 'text/plain') {
+				if (item.kind === "file" && item.type === "text/plain") {
 					// Someone dragged in a .txt file, hand it to the teambuilder
 					app.curRoom.defaultDragEnterTeam(e);
 				}
@@ -57,9 +61,9 @@ function toId() {
 
 		// dropEffect !== 'none' prevents buggy bounce-back animation in
 		// Chrome/Safari/Opera
-		e.originalEvent.dataTransfer.dropEffect = 'move';
+		e.originalEvent.dataTransfer.dropEffect = "move";
 	});
-	$(window).on('drop', function (e) {
+	$(window).on("drop", function (e) {
 		if (/^text/.test(e.target.type)) return; // Ignore text fields
 
 		// The default team drop action for Firefox is to open the team as a
@@ -69,16 +73,22 @@ function toId() {
 		e.preventDefault();
 		if (app.dragging && app.draggingRoom) {
 			app.rooms[app.draggingRoom].defaultDropTeam(e);
-		} else if (e.originalEvent.dataTransfer.files && e.originalEvent.dataTransfer.files[0]) {
+		} else if (
+			e.originalEvent.dataTransfer.files &&
+			e.originalEvent.dataTransfer.files[0]
+		) {
 			var file = e.originalEvent.dataTransfer.files[0];
-			if (file.name.slice(-4) === '.txt' && app.curRoom.id === 'teambuilder') {
+			if (
+				file.name.slice(-4) === ".txt" &&
+				app.curRoom.id === "teambuilder"
+			) {
 				// Someone dragged in a .txt file, hand it to the teambuilder
 				app.curRoom.defaultDragEnterTeam(e);
 				app.curRoom.defaultDropTeam(e);
-			} else if (file.type && file.type.substr(0, 6) === 'image/') {
+			} else if (file.type && file.type.substr(0, 6) === "image/") {
 				// It's an image file, try to set it as a background
 				CustomBackgroundPopup.readFile(file);
-			} else if (file.type && file.type === 'text/html') {
+			} else if (file.type && file.type === "text/html") {
 				BattleRoom.readReplayFile(file);
 			}
 		}
@@ -87,41 +97,56 @@ function toId() {
 		$(document).on("contextmenu", function (e) {
 			e.preventDefault();
 			var target = e.target;
-			var isEditable = (target.tagName === 'TEXTAREA' || target.tagName === 'INPUT');
+			var isEditable =
+				target.tagName === "TEXTAREA" || target.tagName === "INPUT";
 			var menu = new gui.Menu();
 
-			if (isEditable) menu.append(new gui.MenuItem({
-				label: "Cut",
-				click: function () {
-					document.execCommand("cut");
-				}
-			}));
-			var link = $(target).closest('a')[0];
-			if (link) menu.append(new gui.MenuItem({
-				label: "Copy Link URL",
-				click: function () {
-					gui.Clipboard.get().set(link.href);
-				}
-			}));
-			if (target.tagName === 'IMG') menu.append(new gui.MenuItem({
-				label: "Copy Image URL",
-				click: function () {
-					gui.Clipboard.get().set(target.src);
-				}
-			}));
-			menu.append(new gui.MenuItem({
-				label: "Copy",
-				click: function () {
-					document.execCommand("copy");
-				}
-			}));
-			if (isEditable) menu.append(new gui.MenuItem({
-				label: "Paste",
-				enabled: !!gui.Clipboard.get().get(),
-				click: function () {
-					document.execCommand("paste");
-				}
-			}));
+			if (isEditable)
+				menu.append(
+					new gui.MenuItem({
+						label: "Cut",
+						click: function () {
+							document.execCommand("cut");
+						},
+					})
+				);
+			var link = $(target).closest("a")[0];
+			if (link)
+				menu.append(
+					new gui.MenuItem({
+						label: "Copy Link URL",
+						click: function () {
+							gui.Clipboard.get().set(link.href);
+						},
+					})
+				);
+			if (target.tagName === "IMG")
+				menu.append(
+					new gui.MenuItem({
+						label: "Copy Image URL",
+						click: function () {
+							gui.Clipboard.get().set(target.src);
+						},
+					})
+				);
+			menu.append(
+				new gui.MenuItem({
+					label: "Copy",
+					click: function () {
+						document.execCommand("copy");
+					},
+				})
+			);
+			if (isEditable)
+				menu.append(
+					new gui.MenuItem({
+						label: "Paste",
+						enabled: !!gui.Clipboard.get().get(),
+						click: function () {
+							document.execCommand("paste");
+						},
+					})
+				);
 
 			menu.popup(e.originalEvent.x, e.originalEvent.y);
 		});
@@ -138,76 +163,225 @@ function toId() {
 		return false;
 	};
 
-	var User = this.User = Backbone.Model.extend({
+	var User = (this.User = Backbone.Model.extend({
 		defaults: {
-			name: '',
-			userid: '',
+			name: "",
+			userid: "",
 			registered: false,
 			named: false,
 			avatar: 0,
 			settings: {},
-			status: '',
-			away: false
+			status: "",
+			away: false,
 		},
 		initialize: function () {
 			app.addGlobalListeners();
-			app.on('response:userdetails', function (data) {
-				if (data.userid === this.get('userid')) {
-					this.set('avatar', '' + data.avatar);
-				}
-			}, this);
+			app.on(
+				"response:userdetails",
+				function (data) {
+					if (data.userid === this.get("userid")) {
+						this.set("avatar", "" + data.avatar);
+					}
+				},
+				this
+			);
 			var self = this;
-			this.on('change:name', function () {
-				if (!self.get('named')) {
+			this.on("change:name", function () {
+				if (!self.get("named")) {
 					self.nameRegExp = null;
 				} else {
-					var escaped = self.get('name').replace(/[^A-Za-z0-9]+$/, '');
+					var escaped = self.get("name").replace(/[^A-Za-z0-9]+$/, "");
 					// we'll use `,` as a sentinel character to mean "any non-alphanumeric char"
 					// unicode characters can be replaced with any non-alphanumeric char
 					for (var i = escaped.length - 1; i > 0; i--) {
 						if (/[^\ -\~]/.test(escaped[i])) {
-							escaped = escaped.slice(0, i) + ',' + escaped.slice(i + 1);
+							escaped = escaped.slice(0, i) + "," + escaped.slice(i + 1);
 						}
 					}
-					escaped = escaped.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+					escaped = escaped.replace(
+						/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,
+						"\\$&"
+					);
 					escaped = escaped.replace(/,/g, "[^A-Za-z0-9]?");
-					self.nameRegExp = new RegExp('(?:\\b|(?!\\w))' + escaped + '(?:\\b|\\B(?!\\w))', 'i');
+					self.nameRegExp = new RegExp(
+						"(?:\\b|(?!\\w))" + escaped + "(?:\\b|\\B(?!\\w))",
+						"i"
+					);
 				}
 			});
-			this.on('change:settings', function () {
-				Storage.prefs('serversettings', self.get('settings'));
+			this.on("change:settings", function () {
+				Storage.prefs("serversettings", self.get("settings"));
 			});
 
-			var replaceList = {'A': 'ＡⱯȺ', 'B': 'ＢƂƁɃ', 'C': 'ＣꜾȻ', 'D': 'ＤĐƋƊƉꝹ', 'E': 'ＥƐƎ', 'F': 'ＦƑꝻ', 'G': 'ＧꞠꝽꝾ', 'H': 'ＨĦⱧⱵꞍ', 'I': 'ＩƗ', 'J': 'ＪɈ', 'K': 'ＫꞢ', 'L': 'ＬꝆꞀ', 'M': 'ＭⱮƜ', 'N': 'ＮȠƝꞐꞤ', 'O': 'ＯǪǬØǾƆƟꝊꝌ', 'P': 'ＰƤⱣꝐꝒꝔ', 'Q': 'ＱꝖꝘɊ', 'R': 'ＲɌⱤꝚꞦꞂ', 'S': 'ＳẞꞨꞄ', 'T': 'ＴŦƬƮȾꞆ', 'U': 'ＵɄ', 'V': 'ＶƲꝞɅ', 'W': 'ＷⱲ', 'X': 'Ｘ', 'Y': 'ＹɎỾ', 'Z': 'ＺƵȤⱿⱫꝢ', 'a': 'ａąⱥɐ', 'b': 'ｂƀƃɓ', 'c': 'ｃȼꜿↄ', 'd': 'ｄđƌɖɗꝺ', 'e': 'ｅɇɛǝ', 'f': 'ｆḟƒꝼ', 'g': 'ｇɠꞡᵹꝿ', 'h': 'ｈħⱨⱶɥ', 'i': 'ｉɨı', 'j': 'ｊɉ', 'k': 'ｋƙⱪꝁꝃꝅꞣ', 'l': 'ｌſłƚɫⱡꝉꞁꝇ', 'm': 'ｍɱɯ', 'n': 'ｎƞɲŉꞑꞥ', 'o': 'ｏǫǭøǿɔꝋꝍɵ', 'p': 'ｐƥᵽꝑꝓꝕ', 'q': 'ｑɋꝗꝙ', 'r': 'ｒɍɽꝛꞧꞃ', 's': 'ｓꞩꞅẛ', 't': 'ｔŧƭʈⱦꞇ', 'u': 'ｕưừứữửựųṷṵʉ', 'v': 'ｖʋꝟʌ', 'w': 'ｗⱳ', 'x': 'ｘ', 'y': 'ｙɏỿ', 'z': 'ｚƶȥɀⱬꝣ', 'AA': 'Ꜳ', 'AE': 'ÆǼǢ', 'AO': 'Ꜵ', 'AU': 'Ꜷ', 'AV': 'ꜸꜺ', 'AY': 'Ꜽ', 'DZ': 'ǱǄ', 'Dz': 'ǲǅ', 'LJ': 'Ǉ', 'Lj': 'ǈ', 'NJ': 'Ǌ', 'Nj': 'ǋ', 'OI': 'Ƣ', 'OO': 'Ꝏ', 'OU': 'Ȣ', 'TZ': 'Ꜩ', 'VY': 'Ꝡ', 'aa': 'ꜳ', 'ae': 'æǽǣ', 'ao': 'ꜵ', 'au': 'ꜷ', 'av': 'ꜹꜻ', 'ay': 'ꜽ', 'dz': 'ǳǆ', 'hv': 'ƕ', 'lj': 'ǉ', 'nj': 'ǌ', 'oi': 'ƣ', 'ou': 'ȣ', 'oo': 'ꝏ', 'ss': 'ß', 'tz': 'ꜩ', 'vy': 'ꝡ'};
-			var normalizeList = {'A': 'ÀÁÂẦẤẪẨÃĀĂẰẮẴẲȦǠÄǞẢÅǺǍȀȂẠẬẶḀĄ', 'B': 'ḂḄḆ', 'C': 'ĆĈĊČÇḈƇ', 'D': 'ḊĎḌḐḒḎ', 'E': 'ÈÉÊỀẾỄỂẼĒḔḖĔĖËẺĚȄȆẸỆȨḜĘḘḚ', 'F': 'Ḟ', 'G': 'ǴĜḠĞĠǦĢǤƓ', 'H': 'ĤḢḦȞḤḨḪ', 'I': 'ÌÍÎĨĪĬİÏḮỈǏȈȊỊĮḬ', 'J': 'Ĵ', 'K': 'ḰǨḲĶḴƘⱩꝀꝂꝄ', 'L': 'ĿĹĽḶḸĻḼḺŁȽⱢⱠꝈ', 'M': 'ḾṀṂ', 'N': 'ǸŃÑṄŇṆŅṊṈ', 'O': 'ÒÓÔỒỐỖỔÕṌȬṎŌṐṒŎȮȰÖȪỎŐǑȌȎƠỜỚỠỞỢỌỘ', 'P': 'ṔṖ', 'Q': '', 'R': 'ŔṘŘȐȒṚṜŖṞ', 'S': 'ŚṤŜṠŠṦṢṨȘŞⱾ', 'T': 'ṪŤṬȚŢṰṮ', 'U': 'ÙÚÛŨṸŪṺŬÜǛǗǕǙỦŮŰǓȔȖƯỪỨỮỬỰỤṲŲṶṴ', 'V': 'ṼṾ', 'W': 'ẀẂŴẆẄẈ', 'X': 'ẊẌ', 'Y': 'ỲÝŶỸȲẎŸỶỴƳ', 'Z': 'ŹẐŻŽẒẔ', 'a': 'ẚàáâầấẫẩãāăằắẵẳȧǡäǟảåǻǎȁȃạậặḁ', 'b': 'ḃḅḇ', 'c': 'ćĉċčçḉƈ', 'd': 'ḋďḍḑḓḏ', 'e': 'èéêềếễểẽēḕḗĕėëẻěȅȇẹệȩḝęḙḛ', 'f': '', 'g': 'ǵĝḡğġǧģǥ', 'h': 'ĥḣḧȟḥḩḫẖ', 'i': 'ìíîĩīĭïḯỉǐȉȋịįḭ', 'j': 'ĵǰ', 'k': 'ḱǩḳķḵ', 'l': 'ŀĺľḷḹļḽḻ', 'm': 'ḿṁṃ', 'n': 'ǹńñṅňṇņṋṉ', 'o': 'òóôồốỗổõṍȭṏōṑṓŏȯȱöȫỏőǒȍȏơờớỡởợọộ', 'p': 'ṕṗ', 'q': '', 'r': 'ŕṙřȑȓṛṝŗṟ', 's': 'śṥŝṡšṧṣṩșşȿ', 't': 'ṫẗťṭțţṱṯ', 'u': 'ùúûũṹūṻŭüǜǘǖǚủůűǔȕȗụṳ', 'v': 'ṽṿ', 'w': 'ẁẃŵẇẅẘẉ', 'x': 'ẋẍ', 'y': 'ỳýŷỹȳẏÿỷẙỵƴ', 'z': 'źẑżžẓẕ'};
+			var replaceList = {
+				A: "ＡⱯȺ",
+				B: "ＢƂƁɃ",
+				C: "ＣꜾȻ",
+				D: "ＤĐƋƊƉꝹ",
+				E: "ＥƐƎ",
+				F: "ＦƑꝻ",
+				G: "ＧꞠꝽꝾ",
+				H: "ＨĦⱧⱵꞍ",
+				I: "ＩƗ",
+				J: "ＪɈ",
+				K: "ＫꞢ",
+				L: "ＬꝆꞀ",
+				M: "ＭⱮƜ",
+				N: "ＮȠƝꞐꞤ",
+				O: "ＯǪǬØǾƆƟꝊꝌ",
+				P: "ＰƤⱣꝐꝒꝔ",
+				Q: "ＱꝖꝘɊ",
+				R: "ＲɌⱤꝚꞦꞂ",
+				S: "ＳẞꞨꞄ",
+				T: "ＴŦƬƮȾꞆ",
+				U: "ＵɄ",
+				V: "ＶƲꝞɅ",
+				W: "ＷⱲ",
+				X: "Ｘ",
+				Y: "ＹɎỾ",
+				Z: "ＺƵȤⱿⱫꝢ",
+				a: "ａąⱥɐ",
+				b: "ｂƀƃɓ",
+				c: "ｃȼꜿↄ",
+				d: "ｄđƌɖɗꝺ",
+				e: "ｅɇɛǝ",
+				f: "ｆḟƒꝼ",
+				g: "ｇɠꞡᵹꝿ",
+				h: "ｈħⱨⱶɥ",
+				i: "ｉɨı",
+				j: "ｊɉ",
+				k: "ｋƙⱪꝁꝃꝅꞣ",
+				l: "ｌſłƚɫⱡꝉꞁꝇ",
+				m: "ｍɱɯ",
+				n: "ｎƞɲŉꞑꞥ",
+				o: "ｏǫǭøǿɔꝋꝍɵ",
+				p: "ｐƥᵽꝑꝓꝕ",
+				q: "ｑɋꝗꝙ",
+				r: "ｒɍɽꝛꞧꞃ",
+				s: "ｓꞩꞅẛ",
+				t: "ｔŧƭʈⱦꞇ",
+				u: "ｕưừứữửựųṷṵʉ",
+				v: "ｖʋꝟʌ",
+				w: "ｗⱳ",
+				x: "ｘ",
+				y: "ｙɏỿ",
+				z: "ｚƶȥɀⱬꝣ",
+				AA: "Ꜳ",
+				AE: "ÆǼǢ",
+				AO: "Ꜵ",
+				AU: "Ꜷ",
+				AV: "ꜸꜺ",
+				AY: "Ꜽ",
+				DZ: "ǱǄ",
+				Dz: "ǲǅ",
+				LJ: "Ǉ",
+				Lj: "ǈ",
+				NJ: "Ǌ",
+				Nj: "ǋ",
+				OI: "Ƣ",
+				OO: "Ꝏ",
+				OU: "Ȣ",
+				TZ: "Ꜩ",
+				VY: "Ꝡ",
+				aa: "ꜳ",
+				ae: "æǽǣ",
+				ao: "ꜵ",
+				au: "ꜷ",
+				av: "ꜹꜻ",
+				ay: "ꜽ",
+				dz: "ǳǆ",
+				hv: "ƕ",
+				lj: "ǉ",
+				nj: "ǌ",
+				oi: "ƣ",
+				ou: "ȣ",
+				oo: "ꝏ",
+				ss: "ß",
+				tz: "ꜩ",
+				vy: "ꝡ",
+			};
+			var normalizeList = {
+				A: "ÀÁÂẦẤẪẨÃĀĂẰẮẴẲȦǠÄǞẢÅǺǍȀȂẠẬẶḀĄ",
+				B: "ḂḄḆ",
+				C: "ĆĈĊČÇḈƇ",
+				D: "ḊĎḌḐḒḎ",
+				E: "ÈÉÊỀẾỄỂẼĒḔḖĔĖËẺĚȄȆẸỆȨḜĘḘḚ",
+				F: "Ḟ",
+				G: "ǴĜḠĞĠǦĢǤƓ",
+				H: "ĤḢḦȞḤḨḪ",
+				I: "ÌÍÎĨĪĬİÏḮỈǏȈȊỊĮḬ",
+				J: "Ĵ",
+				K: "ḰǨḲĶḴƘⱩꝀꝂꝄ",
+				L: "ĿĹĽḶḸĻḼḺŁȽⱢⱠꝈ",
+				M: "ḾṀṂ",
+				N: "ǸŃÑṄŇṆŅṊṈ",
+				O: "ÒÓÔỒỐỖỔÕṌȬṎŌṐṒŎȮȰÖȪỎŐǑȌȎƠỜỚỠỞỢỌỘ",
+				P: "ṔṖ",
+				Q: "",
+				R: "ŔṘŘȐȒṚṜŖṞ",
+				S: "ŚṤŜṠŠṦṢṨȘŞⱾ",
+				T: "ṪŤṬȚŢṰṮ",
+				U: "ÙÚÛŨṸŪṺŬÜǛǗǕǙỦŮŰǓȔȖƯỪỨỮỬỰỤṲŲṶṴ",
+				V: "ṼṾ",
+				W: "ẀẂŴẆẄẈ",
+				X: "ẊẌ",
+				Y: "ỲÝŶỸȲẎŸỶỴƳ",
+				Z: "ŹẐŻŽẒẔ",
+				a: "ẚàáâầấẫẩãāăằắẵẳȧǡäǟảåǻǎȁȃạậặḁ",
+				b: "ḃḅḇ",
+				c: "ćĉċčçḉƈ",
+				d: "ḋďḍḑḓḏ",
+				e: "èéêềếễểẽēḕḗĕėëẻěȅȇẹệȩḝęḙḛ",
+				f: "",
+				g: "ǵĝḡğġǧģǥ",
+				h: "ĥḣḧȟḥḩḫẖ",
+				i: "ìíîĩīĭïḯỉǐȉȋịįḭ",
+				j: "ĵǰ",
+				k: "ḱǩḳķḵ",
+				l: "ŀĺľḷḹļḽḻ",
+				m: "ḿṁṃ",
+				n: "ǹńñṅňṇņṋṉ",
+				o: "òóôồốỗổõṍȭṏōṑṓŏȯȱöȫỏőǒȍȏơờớỡởợọộ",
+				p: "ṕṗ",
+				q: "",
+				r: "ŕṙřȑȓṛṝŗṟ",
+				s: "śṥŝṡšṧṣṩșşȿ",
+				t: "ṫẗťṭțţṱṯ",
+				u: "ùúûũṹūṻŭüǜǘǖǚủůűǔȕȗụṳ",
+				v: "ṽṿ",
+				w: "ẁẃŵẇẅẘẉ",
+				x: "ẋẍ",
+				y: "ỳýŷỹȳẏÿỷẙỵƴ",
+				z: "źẑżžẓẕ",
+			};
 			for (var i in replaceList) {
-				replaceList[i] = new RegExp('[' + replaceList[i] + ']', 'g');
+				replaceList[i] = new RegExp("[" + replaceList[i] + "]", "g");
 			}
 			for (var i in normalizeList) {
-				normalizeList[i] = new RegExp('[' + normalizeList[i] + ']', 'g');
+				normalizeList[i] = new RegExp("[" + normalizeList[i] + "]", "g");
 			}
 			this.replaceList = replaceList;
 			this.normalizeList = normalizeList;
 		},
 		updateSetting: function (setting, value) {
-			var settings = _.clone(this.get('settings'));
+			var settings = _.clone(this.get("settings"));
 			if (settings[setting] !== value) {
 				switch (setting) {
-				case 'blockPMs':
-					app.send(value ? '/blockpms ' + value : '/unblockpms');
-					break;
-				case 'blockChallenges':
-					app.send(value ? '/blockchallenges' : '/unblockchallenges');
-					break;
-				case 'language':
-					app.send('/language ' + value);
-					break;
-				default:
-					throw new TypeError('Unknown setting:' + setting);
+					case "blockPMs":
+						app.send(value ? "/blockpms " + value : "/unblockpms");
+						break;
+					case "blockChallenges":
+						app.send(value ? "/blockchallenges" : "/unblockchallenges");
+						break;
+					case "language":
+						app.send("/language " + value);
+						break;
+					default:
+						throw new TypeError("Unknown setting:" + setting);
 				}
 				// Optimistically update, might get corrected by the |updateuser| response
 				settings[setting] = value;
-				this.set('settings', settings);
+				this.set("settings", settings);
 			}
 		},
 		/**
@@ -216,9 +390,9 @@ function toId() {
 		 * domain in order to have access to the correct cookies.
 		 */
 		getActionPHP: function () {
-			var ret = '/~~' + Config.server.id + '/action.php';
+			var ret = "/~~" + Config.server.id + "/action.php";
 			if (Config.testclient) {
-				ret = 'https://' + Config.routes.client + ret;
+				ret = "https://" + Config.routes.client + ret;
 			}
 			return (this.getActionPHP = function () {
 				return ret;
@@ -238,27 +412,31 @@ function toId() {
 		 *     triggered if the login server did not return a response
 		 */
 		finishRename: function (name, assertion) {
-			if (assertion.slice(0, 14).toLowerCase() === '<!doctype html') {
+			if (assertion.slice(0, 14).toLowerCase() === "<!doctype html") {
 				// some sort of MitM proxy; ignore it
-				var endIndex = assertion.indexOf('>');
+				var endIndex = assertion.indexOf(">");
 				if (endIndex > 0) assertion = assertion.slice(endIndex + 1);
 			}
-			if (assertion.charAt(0) === '\r') assertion = assertion.slice(1);
-			if (assertion.charAt(0) === '\n') assertion = assertion.slice(1);
-			if (assertion.indexOf('<') >= 0) {
-				app.addPopupMessage("Something is interfering with our connection to the login server. Most likely, your internet provider needs you to re-log-in, or your internet provider is blocking Pokémon Showdown.");
+			if (assertion.charAt(0) === "\r") assertion = assertion.slice(1);
+			if (assertion.charAt(0) === "\n") assertion = assertion.slice(1);
+			if (assertion.indexOf("<") >= 0) {
+				app.addPopupMessage(
+					"Something is interfering with our connection to the login server. Most likely, your internet provider needs you to re-log-in, or your internet provider is blocking Pokémon Showdown."
+				);
 				return;
 			}
-			if (assertion === ';') {
-				this.trigger('login:authrequired', name);
-			} else if (assertion === ';;@gmail') {
-				this.trigger('login:authrequired', name, '@gmail');
-			} else if (assertion.substr(0, 2) === ';;') {
-				this.trigger('login:invalidname', name, assertion.substr(2));
-			} else if (assertion.indexOf('\n') >= 0 || !assertion) {
-				app.addPopupMessage("Something is interfering with our connection to the login server.");
+			if (assertion === ";") {
+				this.trigger("login:authrequired", name);
+			} else if (assertion === ";;@gmail") {
+				this.trigger("login:authrequired", name, "@gmail");
+			} else if (assertion.substr(0, 2) === ";;") {
+				this.trigger("login:invalidname", name, assertion.substr(2));
+			} else if (assertion.indexOf("\n") >= 0 || !assertion) {
+				app.addPopupMessage(
+					"Something is interfering with our connection to the login server."
+				);
 			} else {
-				app.send('/trn ' + name + ',0,' + assertion);
+				app.send("/trn " + name + ",0," + assertion);
 			}
 		},
 		/**
@@ -271,7 +449,7 @@ function toId() {
 		 */
 		rename: function (name) {
 			// | , ; are not valid characters in names
-			name = name.replace(/[\|,;]+/g, '');
+			name = name.replace(/[\|,;]+/g, "");
 			for (var i in this.replaceList) {
 				name = name.replace(this.replaceList[i], i);
 			}
@@ -284,47 +462,56 @@ function toId() {
 				return;
 			}
 
-			if (this.get('userid') !== userid) {
+			if (this.get("userid") !== userid) {
 				var self = this;
-				$.post(this.getActionPHP(), {
-					act: 'getassertion',
-					userid: userid,
-					challstr: this.challstr
-				}, function (data) {
-					self.finishRename(name, data);
-				});
+				$.post(
+					this.getActionPHP(),
+					{
+						act: "getassertion",
+						userid: userid,
+						challstr: this.challstr,
+					},
+					function (data) {
+						self.finishRename(name, data);
+					}
+				);
 			} else {
-				app.send('/trn ' + name);
+				app.send("/trn " + name);
 			}
 		},
 		passwordRename: function (name, password, special) {
 			var self = this;
-			$.post(this.getActionPHP(), {
-				act: 'login',
-				name: name,
-				pass: password,
-				challstr: this.challstr
-			}, Storage.safeJSON(function (data) {
-				if (data && data.curuser && data.curuser.loggedin) {
-					// success!
-					self.set('registered', data.curuser);
-					self.finishRename(name, data.assertion);
-				} else {
-					// wrong password
-					if (special === '@gmail') {
-						try {
-							gapi.auth2.getAuthInstance().signOut(); // eslint-disable-line no-undef
-						} catch (e) {}
+			$.post(
+				this.getActionPHP(),
+				{
+					act: "login",
+					name: name,
+					pass: password,
+					challstr: this.challstr,
+				},
+				Storage.safeJSON(function (data) {
+					if (data && data.curuser && data.curuser.loggedin) {
+						// success!
+						self.set("registered", data.curuser);
+						self.finishRename(name, data.assertion);
+					} else {
+						// wrong password
+						if (special === "@gmail") {
+							try {
+								gapi.auth2.getAuthInstance().signOut(); // eslint-disable-line no-undef
+							} catch (e) {}
+						}
+						app.addPopup(LoginPasswordPopup, {
+							username: name,
+							error: data.error || "Wrong password.",
+							special: special,
+						});
 					}
-					app.addPopup(LoginPasswordPopup, {
-						username: name,
-						error: data.error || 'Wrong password.',
-						special: special
-					});
-				}
-			}), 'text');
+				}),
+				"text"
+			);
 		},
-		challstr: '',
+		challstr: "",
 		receiveChallstr: function (challstr) {
 			if (challstr) {
 				/**
@@ -340,27 +527,39 @@ function toId() {
 				 */
 				this.challstr = challstr;
 				var self = this;
-				$.post(this.getActionPHP(), {
-					act: 'upkeep',
-					challstr: this.challstr
-				}, Storage.safeJSON(function (data) {
-					self.loaded = true;
-					if (!data.username) {
-						app.topbar.updateUserbar();
-						return;
-					}
+				$.post(
+					this.getActionPHP(),
+					{
+						act: "upkeep",
+						challstr: this.challstr,
+					},
+					Storage.safeJSON(function (data) {
+						self.loaded = true;
+						if (!data.username) {
+							app.topbar.updateUserbar();
+							return;
+						}
 
-					// | , ; are not valid characters in names
-					data.username = data.username.replace(/[\|,;]+/g, '');
+						// | , ; are not valid characters in names
+						data.username = data.username.replace(/[\|,;]+/g, "");
 
-					if (data.loggedin) {
-						self.set('registered', {
-							username: data.username,
-							userid: toUserid(data.username)
-						});
-					}
-					self.finishRename(data.username, data.assertion);
-				}), 'text');
+						if (data.loggedin) {
+							self.set("registered", {
+								username: data.username,
+								userid: toUserid(data.username),
+							});
+						}
+						self.finishRename(data.username, data.assertion);
+					}),
+					"text"
+				);
+				/// We can't request a user rename until our challstr comes in from the login server.
+				if (Config.devUsernameOverride) {
+					console.debug(
+						`renaming user to dev override ${Config.devUsernameOverride}`
+					);
+					app.user.rename(Config.devUsernameOverride);
+				}
 			}
 		},
 		/**
@@ -368,28 +567,36 @@ function toId() {
 		 */
 		logout: function () {
 			$.post(this.getActionPHP(), {
-				act: 'logout',
-				userid: this.get('userid')
+				act: "logout",
+				userid: this.get("userid"),
 			});
-			app.send('/logout');
-			app.trigger('init:socketclosed', "You have been logged out and disconnected.<br /><br />If you wanted to change your name while staying connected, use the 'Change Name' button or the '/nick' command.", false);
+			app.send("/logout");
+			app.trigger(
+				"init:socketclosed",
+				"You have been logged out and disconnected.<br /><br />If you wanted to change your name while staying connected, use the 'Change Name' button or the '/nick' command.",
+				false
+			);
 			app.socket.close();
 		},
 		setPersistentName: function (name) {
 			if (location.host !== Config.routes.client) return;
-			$.cookie('showdown_username', (name !== undefined) ? name : this.get('name'), {
-				expires: 14
-			});
-		}
-	});
+			$.cookie(
+				"showdown_username",
+				name !== undefined ? name : this.get("name"),
+				{
+					expires: 14,
+				}
+			);
+		},
+	}));
 
 	this.App = Backbone.Router.extend({
-		root: '/',
+		root: "/",
 		routes: {
-			'*path': 'dispatchFragment'
+			"*path": "dispatchFragment",
 		},
 		events: {
-			'submit form': 'submitSend'
+			"submit form": "submitSend",
 		},
 		focused: true,
 		initialize: function () {
@@ -406,57 +613,66 @@ function toId() {
 			// down
 			// if (document.location.hostname === 'play.pokemonshowdown.com') this.down = true;
 
-			this.addRoom('');
-			this.topbar = new Topbar({el: $('#header')});
+			this.addRoom("");
+			this.topbar = new Topbar({ el: $("#header") });
 			if (this.down) {
 				this.isDisconnected = true;
-			// } else if (location.origin === 'http://smogtours.psim.us') {
-			// 	this.isDisconnected = true;
-			// 	this.addPopup(Popup, {
-			// 		message: "The Smogtours server no longer supports HTTP. Please use https://smogtours.psim.us",
-			// 		type: 'modal'
-			// 	});
+				// } else if (location.origin === 'http://smogtours.psim.us') {
+				// 	this.isDisconnected = true;
+				// 	this.addPopup(Popup, {
+				// 		message: "The Smogtours server no longer supports HTTP. Please use https://smogtours.psim.us",
+				// 		type: 'modal'
+				// 	});
 			} else {
-				if (document.location.hostname === Config.routes.client || Config.testclient) {
-					this.addRoom('rooms', null, true);
+				if (
+					document.location.hostname === Config.routes.client ||
+					Config.testclient
+				) {
+					this.addRoom("rooms", null, true);
 				} else {
-					this.addRoom('lobby', null, true);
+					this.addRoom("lobby", null, true);
 				}
 				Storage.whenPrefsLoaded(function () {
 					if (!Config.server.registered) {
-						app.send('/autojoin');
-						Backbone.history.start({pushState: !Config.testclient});
+						app.send("/autojoin");
+						Backbone.history.start({ pushState: !Config.testclient });
 						return;
 					}
 					// Support legacy tournament setting and migrate to new pref
-					if (Dex.prefs('notournaments') !== undefined) {
-						Storage.prefs('tournaments', Dex.prefs('notournaments') ? 'hide' : 'notify');
-						Storage.prefs('notournaments', null, true);
+					if (Dex.prefs("notournaments") !== undefined) {
+						Storage.prefs(
+							"tournaments",
+							Dex.prefs("notournaments") ? "hide" : "notify"
+						);
+						Storage.prefs("notournaments", null, true);
 					}
-					var autojoin = (Dex.prefs('autojoin') || '');
+					var autojoin = Dex.prefs("autojoin") || "";
 					var autojoinIds = [];
-					if (typeof autojoin === 'string') {
+					if (typeof autojoin === "string") {
 						// Use the existing autojoin string for showdown, and an empty string for other servers.
-						if (Config.server.id !== 'showdown') autojoin = '';
+						if (Config.server.id !== "showdown") autojoin = "";
 					} else {
 						// If there is not autojoin data for this server, use a empty string.
-						autojoin = autojoin[Config.server.id] || '';
+						autojoin = autojoin[Config.server.id] || "";
 					}
 					if (autojoin) {
-						var autojoins = autojoin.split(',');
+						var autojoins = autojoin.split(",");
 						for (var i = 0; i < autojoins.length; i++) {
 							var roomid = toRoomid(autojoins[i]);
 							app.addRoom(roomid, null, true, autojoins[i]);
-							if (roomid === 'staff' || roomid === 'upperstaff') continue;
-							if (Config.server.id !== 'showdown' && roomid === 'lobby') continue;
+							if (roomid === "staff" || roomid === "upperstaff")
+								continue;
+							if (Config.server.id !== "showdown" && roomid === "lobby")
+								continue;
 							autojoinIds.push(roomid);
 						}
 					}
-					app.send('/autojoin ' + autojoinIds.join(','));
-					var settings = Dex.prefs('serversettings') || {};
-					if (Object.keys(settings).length) app.user.set('settings', settings);
+					app.send("/autojoin " + autojoinIds.join(","));
+					var settings = Dex.prefs("serversettings") || {};
+					if (Object.keys(settings).length)
+						app.user.set("settings", settings);
 					// HTML5 history throws exceptions when running on file://
-					Backbone.history.start({pushState: !Config.testclient});
+					Backbone.history.start({ pushState: !Config.testclient });
 					app.ignore = app.loadIgnore();
 				});
 			}
@@ -464,61 +680,74 @@ function toId() {
 			var self = this;
 
 			Storage.whenPrefsLoaded(function () {
-				Storage.prefs('bg', null);
+				Storage.prefs("bg", null);
 
-				var muted = Dex.prefs('mute');
+				var muted = Dex.prefs("mute");
 				BattleSound.setMute(muted);
 
-				var theme = Dex.prefs('theme');
-				var colorSchemeQuery = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
-				var dark = theme === 'dark' || (theme === 'system' && colorSchemeQuery && colorSchemeQuery.matches);
-				$('html').toggleClass('dark', dark);
-				if (colorSchemeQuery && colorSchemeQuery.media !== 'not all') {
-					colorSchemeQuery.addEventListener('change', function (cs) {
-						if (Dex.prefs('theme') === 'system') $('html').toggleClass('dark', cs.matches);
+				var theme = Dex.prefs("theme");
+				var colorSchemeQuery =
+					window.matchMedia &&
+					window.matchMedia("(prefers-color-scheme: dark)");
+				var dark =
+					theme === "dark" ||
+					(theme === "system" &&
+						colorSchemeQuery &&
+						colorSchemeQuery.matches);
+				$("html").toggleClass("dark", dark);
+				if (colorSchemeQuery && colorSchemeQuery.media !== "not all") {
+					colorSchemeQuery.addEventListener("change", function (cs) {
+						if (Dex.prefs("theme") === "system")
+							$("html").toggleClass("dark", cs.matches);
 					});
 				}
 
-				var effectVolume = Dex.prefs('effectvolume');
-				if (effectVolume !== undefined) BattleSound.setEffectVolume(effectVolume);
+				var effectVolume = Dex.prefs("effectvolume");
+				if (effectVolume !== undefined)
+					BattleSound.setEffectVolume(effectVolume);
 
-				var musicVolume = Dex.prefs('musicvolume');
-				if (musicVolume !== undefined) BattleSound.setBgmVolume(musicVolume);
+				var musicVolume = Dex.prefs("musicvolume");
+				if (musicVolume !== undefined)
+					BattleSound.setBgmVolume(musicVolume);
 
-				if (Dex.prefs('logchat')) Storage.startLoggingChat();
-				if (Dex.prefs('showdebug')) {
-					var debugStyle = $('#debugstyle').get(0);
-					var onCSS = '.debug {display: block;}';
+				if (Dex.prefs("logchat")) Storage.startLoggingChat();
+				if (Dex.prefs("showdebug")) {
+					var debugStyle = $("#debugstyle").get(0);
+					var onCSS = ".debug {display: block;}";
 					if (!debugStyle) {
-						$('head').append('<style id="debugstyle">' + onCSS + '</style>');
+						$("head").append(
+							'<style id="debugstyle">' + onCSS + "</style>"
+						);
 					} else {
 						debugStyle.innerHTML = onCSS;
 					}
 				}
 
-				if (Dex.prefs('onepanel')) {
+				if (Dex.prefs("onepanel")) {
 					self.singlePanelMode = true;
 					self.updateLayout();
 				}
 
 				var noAnim = true;
-				if (Dex.prefs('bwgfx') || noAnim) {
+				if (Dex.prefs("bwgfx") || noAnim) {
 					// since xy data is loaded by default, only call
 					// loadSpriteData if we want bw sprites or if we need bw
 					// sprite data (if animations are disabled)
-					Dex.loadSpriteData('bw');
+					Dex.loadSpriteData("bw");
 				}
 			});
 
-			this.on('init:unsupported', function () {
-				self.addPopupMessage('Your browser is unsupported.');
+			this.on("init:unsupported", function () {
+				self.addPopupMessage("Your browser is unsupported.");
 			});
 
-			this.on('init:nothirdparty', function () {
-				self.addPopupMessage('You have third-party cookies disabled in your browser, which is likely to cause problems. You should enable them and then refresh this page.');
+			this.on("init:nothirdparty", function () {
+				self.addPopupMessage(
+					"You have third-party cookies disabled in your browser, which is likely to cause problems. You should enable them and then refresh this page."
+				);
 			});
 
-			this.on('init:socketclosed', function (message, showNotification) {
+			this.on("init:socketclosed", function (message, showNotification) {
 				// Display a desktop notification if the user won't immediately see the popup.
 				if (self.isDisconnected) return;
 
@@ -526,64 +755,82 @@ function toId() {
 				this.hostCheckInterval = null;
 				self.isDisconnected = true;
 
-				if (showNotification !== false && (self.popups.length || !self.focused) && window.Notification) {
-					self.rooms[''].requestNotifications();
-					self.rooms[''].notifyOnce("Disconnected", "You have been disconnected from Pokémon Showdown.", 'disconnected');
+				if (
+					showNotification !== false &&
+					(self.popups.length || !self.focused) &&
+					window.Notification
+				) {
+					self.rooms[""].requestNotifications();
+					self.rooms[""].notifyOnce(
+						"Disconnected",
+						"You have been disconnected from Pokémon Showdown.",
+						"disconnected"
+					);
 				}
 
-				self.rooms[''].updateFormats();
-				$('.pm-log-add form').html('<small>You are disconnected and cannot chat.</small>');
-				$('.chat-log-add').html('<small>You are disconnected and cannot chat.</small>');
-				$('.battle-log-add').html('<small>You are disconnected and cannot chat.</small>');
+				self.rooms[""].updateFormats();
+				$(".pm-log-add form").html(
+					"<small>You are disconnected and cannot chat.</small>"
+				);
+				$(".chat-log-add").html(
+					"<small>You are disconnected and cannot chat.</small>"
+				);
+				$(".battle-log-add").html(
+					"<small>You are disconnected and cannot chat.</small>"
+				);
 
-				self.reconnectPending = (message || true);
-				if (!self.popups.length) self.addPopup(ReconnectPopup, {message: message});
+				self.reconnectPending = message || true;
+				if (!self.popups.length)
+					self.addPopup(ReconnectPopup, { message: message });
 			});
 
-			this.on('init:connectionerror', function () {
+			this.on("init:connectionerror", function () {
 				self.isDisconnected = true;
-				self.rooms[''].updateFormats();
-				self.addPopup(ReconnectPopup, {cantconnect: true});
+				self.rooms[""].updateFormats();
+				self.addPopup(ReconnectPopup, { cantconnect: true });
 			});
 
-			this.user.on('login:invalidname', function (name, reason) {
-				self.addPopup(LoginPopup, {name: name, reason: reason});
+			this.user.on("login:invalidname", function (name, reason) {
+				self.addPopup(LoginPopup, { name: name, reason: reason });
 			});
 
-			this.user.on('login:authrequired', function (name, special) {
-				self.addPopup(LoginPasswordPopup, {username: name, special: special});
+			this.user.on("login:authrequired", function (name, special) {
+				self.addPopup(LoginPasswordPopup, {
+					username: name,
+					special: special,
+				});
 			});
 
-			this.on('response:savereplay', this.uploadReplay, this);
+			this.on("response:savereplay", this.uploadReplay, this);
 
-			this.on('response:rooms', this.roomsResponse, this);
+			this.on("response:rooms", this.roomsResponse, this);
 
 			if (window.nodewebkit) {
-				nwWindow.on('focus', function () {
+				nwWindow.on("focus", function () {
 					if (!self.focused) {
 						self.focused = true;
 						if (self.curRoom) self.curRoom.dismissNotification();
 						if (self.curSideRoom) self.curSideRoom.dismissNotification();
 					}
 				});
-				nwWindow.on('blur', function () {
+				nwWindow.on("blur", function () {
 					self.focused = false;
 				});
 			} else {
-				$(window).on('focus click', function () {
+				$(window).on("focus click", function () {
 					if (!self.focused) {
 						self.focused = true;
 						if (self.curRoom) self.curRoom.dismissNotification();
 						if (self.curSideRoom) self.curSideRoom.dismissNotification();
 					}
 				});
-				$(window).on('blur', function () {
+				$(window).on("blur", function () {
 					self.focused = false;
 				});
 			}
 
-			$(window).on('beforeunload', function (e) {
-				if (Config.server && Config.server.host === 'localhost') return;
+			$(window).on("beforeunload", function (e) {
+				if (Config.server && Config.server.host === "localhost") return;
 				if (app.isDisconnected) return;
 				for (var id in self.rooms) {
 					var room = self.rooms[id];
@@ -593,21 +840,27 @@ function toId() {
 					}
 				}
 
-				if (Dex.prefs('refreshprompt')) {
+				if (Dex.prefs("refreshprompt")) {
 					e.returnValue = "Are you sure you want to refresh?";
 					return e.returnValue;
 				}
 			});
 
-			$(window).on('keydown', function (e) {
+			$(window).on("keydown", function (e) {
 				var el = e.target;
 				var tagName = el.tagName.toUpperCase();
 
 				// keypress happened in an empty textarea or a button
-				var safeLocation = ((tagName === 'TEXTAREA' && !el.value.length) || tagName === 'BUTTON');
-				var isMac = (navigator.userAgent.indexOf("Mac") !== -1);
+				var safeLocation =
+					(tagName === "TEXTAREA" && !el.value.length) ||
+					tagName === "BUTTON";
+				var isMac = navigator.userAgent.indexOf("Mac") !== -1;
 
-				if (e.keyCode === 70 && window.nodewebkit && (isMac ? e.metaKey : e.ctrlKey)) {
+				if (
+					e.keyCode === 70 &&
+					window.nodewebkit &&
+					(isMac ? e.metaKey : e.ctrlKey)
+				) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
 					var query = window.getSelection().toString();
@@ -615,14 +868,21 @@ function toId() {
 					if (query) window.find(query);
 					return;
 				}
-				if (e.keyCode === 71 && window.nodewebkit && (isMac ? e.metaKey : e.ctrlKey)) {
+				if (
+					e.keyCode === 71 &&
+					window.nodewebkit &&
+					(isMac ? e.metaKey : e.ctrlKey)
+				) {
 					e.preventDefault();
 					e.stopImmediatePropagation();
 					var query = window.getSelection().toString();
 					if (query) window.find(query);
 					return;
 				}
-				if (app.curSideRoom && $(e.target).closest(app.curSideRoom.$el).length) {
+				if (
+					app.curSideRoom &&
+					$(e.target).closest(app.curSideRoom.$el).length
+				) {
 					// keypress happened in sideroom
 					if (e.shiftKey && e.keyCode === 37 && safeLocation) {
 						// Shift+Left on desktop client
@@ -636,13 +896,22 @@ function toId() {
 							e.preventDefault();
 							e.stopImmediatePropagation();
 						}
-					} else if (e.keyCode === 37 && safeLocation || window.nodewebkit && e.ctrlKey && e.shiftKey && e.keyCode === 9) {
+					} else if (
+						(e.keyCode === 37 && safeLocation) ||
+						(window.nodewebkit &&
+							e.ctrlKey &&
+							e.shiftKey &&
+							e.keyCode === 9)
+					) {
 						// Left or Ctrl+Shift+Tab on desktop client
 						if (app.focusRoomBy(app.curSideRoom, -1)) {
 							e.preventDefault();
 							e.stopImmediatePropagation();
 						}
-					} else if (e.keyCode === 39 && safeLocation || window.nodewebkit && e.ctrlKey && e.keyCode === 9) {
+					} else if (
+						(e.keyCode === 39 && safeLocation) ||
+						(window.nodewebkit && e.ctrlKey && e.keyCode === 9)
+					) {
 						// Right or Ctrl+Tab on desktop client
 						if (app.focusRoomBy(app.curSideRoom, 1)) {
 							e.preventDefault();
@@ -664,13 +933,19 @@ function toId() {
 						e.preventDefault();
 						e.stopImmediatePropagation();
 					}
-				} else if (e.keyCode === 37 && safeLocation || window.nodewebkit && e.ctrlKey && e.shiftKey && e.keyCode === 9) {
+				} else if (
+					(e.keyCode === 37 && safeLocation) ||
+					(window.nodewebkit && e.ctrlKey && e.shiftKey && e.keyCode === 9)
+				) {
 					// Left or Ctrl+Shift+Tab on desktop client
 					if (app.focusRoomBy(app.curRoom, -1)) {
 						e.preventDefault();
 						e.stopImmediatePropagation();
 					}
-				} else if (e.keyCode === 39 && safeLocation || window.nodewebkit && e.ctrlKey && e.keyCode === 9) {
+				} else if (
+					(e.keyCode === 39 && safeLocation) ||
+					(window.nodewebkit && e.ctrlKey && e.keyCode === 9)
+				) {
 					// Right or Ctrl+Tab on desktop client
 					if (app.focusRoomBy(app.curRoom, 1)) {
 						e.preventDefault();
@@ -682,7 +957,7 @@ function toId() {
 			Storage.whenAppLoaded.load(this);
 
 			// load custom colors from loginserver
-			$.get('/config/colors.json', {}, function (data) {
+			$.get("/config/colors.json", {}, function (data) {
 				Object.assign(Config.customcolors, data);
 			});
 
@@ -732,7 +1007,11 @@ function toId() {
 			if (Config.bannedHosts) {
 				for (var i = 0; i < Config.bannedHosts.length; i++) {
 					var host = Config.bannedHosts[i];
-					if (typeof host === 'string' ? Config.server.host === host : host.test(Config.server.host)) {
+					if (
+						typeof host === "string"
+							? Config.server.host === host
+							: host.test(Config.server.host)
+					) {
 						Config.server.banned = true;
 						break;
 					}
@@ -740,62 +1019,81 @@ function toId() {
 			}
 
 			if (Config.server.banned) {
-				this.addPopupMessage("This server has either been deleted for breaking US law or PS global rules, or it is hosted on a platform that's often used to host rulebreaking servers.");
+				this.addPopupMessage(
+					"This server has either been deleted for breaking US law or PS global rules, or it is hosted on a platform that's often used to host rulebreaking servers."
+				);
 				return;
 			}
 
 			var self = this;
 			var constructSocket = function () {
-				var protocol = (Config.server.port === 443 || Config.server.https) ? 'https' : 'http';
+				var protocol =
+					Config.server.port === 443 || Config.server.https
+						? "https"
+						: "http";
 				Config.server.host = $.trim(Config.server.host);
 				try {
-					if (Config.server.host === 'localhost') {
+					if (Config.server.host === "localhost") {
 						// connecting to localhost from psim.us is now banned as of Chrome 94
 						// thanks Docker for having vulns
 						// https://wicg.github.io/cors-rfc1918
 						// anyway, this affects SockJS because it makes HTTP requests to localhost
 						// but it turns out that making direct WebSocket connections to localhost is
 						// still supported, so we'll just bypass SockJS and use WebSocket directly.
-						var possiblePort = new URL(document.location + self.query).searchParams.get('port');
+						var possiblePort = new URL(
+							document.location + self.query
+						).searchParams.get("port");
 						// We need to bypass the port as well because on most modern browsers, http gets forced
 						// to https, which means a ws connection is made to port 443 instead of wherever it's actually running,
 						// thus ensuring a failed connection.
 						var port = possiblePort || Config.server.port;
 						console.log("Bypassing SockJS for localhost");
-						var url = 'ws://' + Config.server.host + ':' + port + Config.sockjsprefix + '/websocket';
+						var url =
+							"ws://" +
+							Config.server.host +
+							":" +
+							port +
+							Config.sockjsprefix +
+							"/websocket";
 						console.log(url);
 						return new WebSocket(url);
 					}
 					return new SockJS(
-						protocol + '://' + Config.server.host + ':' + Config.server.port + Config.sockjsprefix,
-						[], {timeout: 5 * 60 * 1000}
+						protocol +
+							"://" +
+							Config.server.host +
+							":" +
+							Config.server.port +
+							Config.sockjsprefix,
+						[],
+						{ timeout: 5 * 60 * 1000 }
 					);
 				} catch (err) {
 					// The most common case this happens is if an HTTPS connection fails,
 					// and we fall back to HTTP, which throws a SecurityError if the URL
 					// is HTTPS
-					self.trigger('init:connectionerror');
+					self.trigger("init:connectionerror");
 					return null;
 				}
 			};
 			this.socket = constructSocket();
 
 			var socketopened = false;
-			var altport = (Config.server.port === Config.server.altport);
+			var altport = Config.server.port === Config.server.altport;
 			var altprefix = false;
 
 			this.socket.onopen = function () {
 				socketopened = true;
 				if (altport && window.ga) {
-					ga('send', 'event', 'Alt port connection', Config.server.id);
+					ga("send", "event", "Alt port connection", Config.server.id);
 				}
-				self.trigger('init:socketopened');
+				self.trigger("init:socketopened");
 
-				var avatar = Dex.prefs('avatar');
+				var avatar = Dex.prefs("avatar");
 				if (avatar) {
 					// This will be compatible even with servers that don't support
 					// the second argument for /avatar yet.
-					self.send('/avatar ' + avatar + ',1');
+					self.send("/avatar " + avatar + ",1");
 				}
 
 				if (self.sendQueue) {
@@ -816,7 +1114,7 @@ function toId() {
 			};
 			this.socket.onmessage = function (msg) {
 				if (window.console && console.log) {
-					console.log('<< ' + msg.data);
+					console.log("<< " + msg.data);
 				}
 				self.receive(msg.data);
 			};
@@ -837,22 +1135,23 @@ function toId() {
 					}
 					if (!altprefix) {
 						altprefix = true;
-						Config.sockjsprefix = '';
+						Config.sockjsprefix = "";
 						self.socket = reconstructSocket(self.socket);
 						return;
 					}
-					return self.trigger('init:connectionerror');
+					return self.trigger("init:connectionerror");
 				}
-				self.trigger('init:socketclosed');
+				self.trigger("init:socketclosed");
 			};
 		},
 		dispatchFragment: function (fragment) {
 			if (!Config.testclient && location.search && window.history) {
 				history.replaceState(null, null, location.pathname);
 			}
-			if (fragment && fragment.includes('.')) fragment = '';
-			this.fragment = fragment = toRoomid(fragment || '');
-			if (this.initialFragment === undefined) this.initialFragment = fragment;
+			if (fragment && fragment.includes(".")) fragment = "";
+			this.fragment = fragment = toRoomid(fragment || "");
+			if (this.initialFragment === undefined)
+				this.initialFragment = fragment;
 			this.tryJoinRoom(fragment);
 			this.updateTitle(this.rooms[fragment]);
 		},
@@ -861,30 +1160,39 @@ function toId() {
 		 */
 		send: function (data, room) {
 			if (room && room !== true) {
-				data = room + '|' + data;
+				data = room + "|" + data;
 			} else if (room !== true) {
-				data = '|' + data;
+				data = "|" + data;
 			}
-			if (!this.socket || (this.socket.readyState !== SockJS.OPEN)) {
+			if (!this.socket || this.socket.readyState !== SockJS.OPEN) {
 				if (!this.sendQueue) this.sendQueue = [];
 				this.sendQueue.push(data);
 				return;
 			}
 			if (window.console && console.log) {
-				console.log('>> ' + data);
+				console.log(">> " + data);
 			}
 			this.socket.send(data);
 		},
 		serializeForm: function (form, checkboxOnOff) {
 			// querySelector dates back to IE8 so we can use it
 			// fortunate, because form serialization is a HUGE MESS in older browsers
-			var elements = form.querySelectorAll('input[name], select[name], textarea[name], keygen[name]');
+			var elements = form.querySelectorAll(
+				"input[name], select[name], textarea[name], keygen[name]"
+			);
 			var out = [];
 			for (var i = 0; i < elements.length; i++) {
 				var element = elements[i];
-				if (element.type === 'checkbox' && !element.value && checkboxOnOff) {
-					out.push([element.name, element.checked ? 'on' : 'off']);
-				} else if (!['checkbox', 'radio'].includes(element.type) || element.checked) {
+				if (
+					element.type === "checkbox" &&
+					!element.value &&
+					checkboxOnOff
+				) {
+					out.push([element.name, element.checked ? "on" : "off"]);
+				} else if (
+					!["checkbox", "radio"].includes(element.type) ||
+					element.checked
+				) {
 					out.push([element.name, element.value]);
 				}
 			}
@@ -896,16 +1204,19 @@ function toId() {
 			// handling is a lot more straightforward because it doesn't rely on Backbone's event
 			// dispatch system.
 			var target = e.currentTarget;
-			var dataSend = target.getAttribute('data-submitsend');
+			var dataSend = target.getAttribute("data-submitsend");
 			if (dataSend) {
 				var toSend = dataSend;
 				var entries = this.serializeForm(target, true);
 				for (var i = 0; i < entries.length; i++) {
-					toSend = toSend.replace('{' + entries[i][0] + '}', entries[i][1]);
+					toSend = toSend.replace(
+						"{" + entries[i][0] + "}",
+						entries[i][1]
+					);
 				}
-				toSend = toSend.replace(/\{[a-z]+\}/g, '');
+				toSend = toSend.replace(/\{[a-z]+\}/g, "");
 				this.send(toSend);
-				e.currentTarget.innerText = 'Submitted!';
+				e.currentTarget.innerText = "Submitted!";
 				e.preventDefault();
 				e.stopPropagation();
 			}
@@ -914,56 +1225,64 @@ function toId() {
 		 * Send team to sim server
 		 */
 		sendTeam: function (team) {
-			var packedTeam = '' + Storage.getPackedTeam(team);
+			var packedTeam = "" + Storage.getPackedTeam(team);
 			if (packedTeam.length > 25 * 1024 - 6) {
 				alert("Your team is over 25 KB. Please use a smaller team.");
 				return;
 			}
-			this.send('/utm ' + packedTeam);
+			this.send("/utm " + packedTeam);
 		},
 		/**
 		 * Receive from sim server
 		 */
 		receive: function (data) {
-			var roomid = '';
+			var roomid = "";
 			var autojoined = false;
-			if (data.charAt(0) === '>') {
-				var nlIndex = data.indexOf('\n');
+			if (data.charAt(0) === ">") {
+				var nlIndex = data.indexOf("\n");
 				if (nlIndex < 0) return;
 				roomid = toRoomid(data.substr(1, nlIndex - 1));
 				data = data.substr(nlIndex + 1);
 			}
-			if (data.substr(0, 6) === '|init|') {
-				if (!roomid) roomid = 'lobby';
+			if (data.substr(0, 6) === "|init|") {
+				if (!roomid) roomid = "lobby";
 				var roomType = data.substr(6);
-				var roomTypeLFIndex = roomType.indexOf('\n');
-				if (roomTypeLFIndex >= 0) roomType = roomType.substr(0, roomTypeLFIndex);
+				var roomTypeLFIndex = roomType.indexOf("\n");
+				if (roomTypeLFIndex >= 0)
+					roomType = roomType.substr(0, roomTypeLFIndex);
 				roomType = toID(roomType);
-				if (this.rooms[roomid] || roomid === 'staff' || roomid === 'upperstaff') {
+				if (
+					this.rooms[roomid] ||
+					roomid === "staff" ||
+					roomid === "upperstaff"
+				) {
 					// autojoin rooms are joined in background
 					this.addRoom(roomid, roomType, true);
 				} else {
 					this.joinRoom(roomid, roomType, true);
 				}
-				if (roomType === 'chat') autojoined = true;
-			} else if ((data + '|').substr(0, 8) === '|expire|') {
+				if (roomType === "chat") autojoined = true;
+			} else if ((data + "|").substr(0, 8) === "|expire|") {
 				var room = this.rooms[roomid];
 				if (room) {
-					room.expired = (data.substr(8) || true);
+					room.expired = data.substr(8) || true;
 					if (room.updateUser) room.updateUser();
 				}
 				return;
-			} else if ((data + '|').substr(0, 8) === '|deinit|' || (data + '|').substr(0, 8) === '|noinit|') {
-				if (!roomid) roomid = 'lobby';
+			} else if (
+				(data + "|").substr(0, 8) === "|deinit|" ||
+				(data + "|").substr(0, 8) === "|noinit|"
+			) {
+				if (!roomid) roomid = "lobby";
 
 				if (this.rooms[roomid] && this.rooms[roomid].expired) {
 					// expired rooms aren't closed when left
 					return;
 				}
 
-				var isdeinit = (data.charAt(1) === 'd');
+				var isdeinit = data.charAt(1) === "d";
 				data = data.substr(8);
-				var pipeIndex = data.indexOf('|');
+				var pipeIndex = data.indexOf("|");
 				var errormessage;
 				if (pipeIndex >= 0) {
 					errormessage = data.substr(pipeIndex + 1);
@@ -971,50 +1290,78 @@ function toId() {
 				}
 				// handle error codes here
 				// data is the error code
-				if (data === 'namerequired') {
+				if (data === "namerequired") {
 					var self = this;
-					this.once('init:choosename', function () {
-						self.send('/join ' + roomid);
+					this.once("init:choosename", function () {
+						self.send("/join " + roomid);
 					});
-				} else if (data === 'rename') {
+				} else if (data === "rename") {
 					// |newid|newtitle
-					var parts = errormessage.split('|');
+					var parts = errormessage.split("|");
 					this.renameRoom(roomid, parts[0], parts[1]);
-				} else if (data === 'nonexistent' && Config.server.id && roomid.slice(0, 7) === 'battle-' && errormessage) {
+				} else if (
+					data === "nonexistent" &&
+					Config.server.id &&
+					roomid.slice(0, 7) === "battle-" &&
+					errormessage
+				) {
 					var replayid = roomid.slice(7);
-					if (Config.server.id !== 'showdown') replayid = Config.server.id + '-' + replayid;
-					var replayLink = 'https://' + Config.routes.replays + '/' + replayid;
-					$.ajax(replayLink + '.json', {dataType: 'json'}).done(function (replay) {
-						if (replay) {
-							var title = replay.p1 + ' vs. ' + replay.p2;
-							app.receive('>battle-' + replayid + '\n|init|battle\n|title|' + title + '\n' + replay.log);
-							app.receive('>battle-' + replayid + '\n|expire|<a href=' + replayLink + ' target="_blank" class="no-panel-intercept">Open replay in new tab</a>');
-						} else {
-							errormessage += '\n\nResponse received, but no data.';
+					if (Config.server.id !== "showdown")
+						replayid = Config.server.id + "-" + replayid;
+					var replayLink =
+						"https://" + Config.routes.replays + "/" + replayid;
+					$.ajax(replayLink + ".json", { dataType: "json" })
+						.done(function (replay) {
+							if (replay) {
+								var title = replay.p1 + " vs. " + replay.p2;
+								app.receive(
+									">battle-" +
+										replayid +
+										"\n|init|battle\n|title|" +
+										title +
+										"\n" +
+										replay.log
+								);
+								app.receive(
+									">battle-" +
+										replayid +
+										"\n|expire|<a href=" +
+										replayLink +
+										' target="_blank" class="no-panel-intercept">Open replay in new tab</a>'
+								);
+							} else {
+								errormessage += "\n\nResponse received, but no data.";
+								app.addPopupMessage(errormessage);
+							}
+						})
+						.fail(function () {
+							app.removeRoom(roomid, true);
+							errormessage +=
+								"\n\nThe battle you're looking for has expired. Battles expire after 15 minutes of inactivity unless they're saved.\nIn the future, remember to click \"Save replay\" to save a replay permanently.";
 							app.addPopupMessage(errormessage);
-						}
-					}).fail(function () {
-						app.removeRoom(roomid, true);
-						errormessage += "\n\nThe battle you're looking for has expired. Battles expire after 15 minutes of inactivity unless they're saved.\nIn the future, remember to click \"Save replay\" to save a replay permanently.";
-						app.addPopupMessage(errormessage);
-					});
+						});
 				} else {
-					if (isdeinit) { // deinit
-						if (this.rooms[roomid] && this.rooms[roomid].type === 'chat') {
+					if (isdeinit) {
+						// deinit
+						if (
+							this.rooms[roomid] &&
+							this.rooms[roomid].type === "chat"
+						) {
 							this.removeRoom(roomid, true);
 							this.updateAutojoin();
 						} else {
 							this.removeRoom(roomid, true);
 						}
-					} else { // noinit
+					} else {
+						// noinit
 						this.unjoinRoom(roomid);
-						if (roomid === 'lobby') this.joinRoom('rooms');
+						if (roomid === "lobby") this.joinRoom("rooms");
 					}
 					if (errormessage) this.addPopupMessage(errormessage);
 				}
 				return;
-			} else if (data.substr(0, 3) === '|N|') {
-				var names = data.substr(1).split('|');
+			} else if (data.substr(0, 3) === "|N|") {
+				var names = data.substr(1).split("|");
 				if (app.ignore[toUserid(names[2])]) {
 					app.ignore[toUserid(names[1])] = 1;
 				}
@@ -1035,184 +1382,198 @@ function toId() {
 			// list, we'll assume global; otherwise, we'll assume lobby.
 
 			var parts;
-			if (data.charAt(0) === '|') {
-				parts = data.substr(1).split('|');
+			if (data.charAt(0) === "|") {
+				parts = data.substr(1).split("|");
 			} else {
 				parts = [];
 			}
 
 			switch (parts[0]) {
-			case 'customgroups':
-				var nlIndex = data.indexOf('\n');
-				if (nlIndex > 0) {
-					this.receive(data.substr(nlIndex + 1));
-				}
-
-				var tarRow = data.slice(14, nlIndex);
-				this.parseGroups(tarRow);
-				break;
-
-			case 'challstr':
-				if (parts[2]) {
-					this.user.receiveChallstr(parts[1] + '|' + parts[2]);
-				} else {
-					this.user.receiveChallstr(parts[1]);
-				}
-				break;
-
-			case 'formats':
-				this.parseFormats(parts);
-				break;
-
-			case 'updateuser':
-				var nlIndex = data.indexOf('\n');
-				if (nlIndex > 0) {
-					this.receive(data.substr(nlIndex + 1));
-					parts = data.slice(1, nlIndex).split('|');
-				}
-				var parsed = BattleTextParser.parseNameParts(parts[1]);
-				var named = !!+parts[2];
-
-				var userid = toUserid(parsed.name);
-				if (userid === this.user.get('userid') && parsed.name !== this.user.get('name')) {
-					$.post(app.user.getActionPHP(), {
-						act: 'changeusername',
-						username: parsed.name
-					}, function () {}, 'text');
-				}
-
-				var settings = _.clone(app.user.get('settings'));
-				if (parts.length > 4) {
-					// Update our existing settings based on what the server has sent us.
-					// This approach is more robust as it works regardless of whether the
-					// server sends us all the values or just the diffs.
-					var update = JSON.parse(parts[4]);
-					for (var key in update) {
-						settings[key] = update[key];
+				case "customgroups":
+					var nlIndex = data.indexOf("\n");
+					if (nlIndex > 0) {
+						this.receive(data.substr(nlIndex + 1));
 					}
-				}
 
-				this.user.set({
-					name: parsed.name,
-					userid: userid,
-					named: named,
-					avatar: parts[3],
-					settings: settings,
-					status: parsed.status,
-					away: parsed.away
-				});
-				this.user.setPersistentName(named ? parsed.name : null);
-				if (named) {
-					this.trigger('init:choosename');
-				}
-				if (app.ignore[userid]) {
-					delete app.ignore[userid];
-					app.saveIgnore();
-				}
-				break;
+					var tarRow = data.slice(14, nlIndex);
+					this.parseGroups(tarRow);
+					break;
 
-			case 'nametaken':
-				app.addPopup(LoginPopup, {name: parts[1] || '', error: parts[2] || ''});
-				break;
+				case "challstr":
+					if (parts[2]) {
+						this.user.receiveChallstr(parts[1] + "|" + parts[2]);
+					} else {
+						this.user.receiveChallstr(parts[1]);
+					}
+					break;
 
-			case 'queryresponse':
-				var responseData = JSON.parse(data.substr(16 + parts[1].length));
-				app.trigger('response:' + parts[1], responseData);
-				break;
+				case "formats":
+					this.parseFormats(parts);
+					break;
 
-			case 'updatechallenges':
-				if (this.rooms['']) {
-					this.rooms[''].updateChallenges(JSON.parse(data.substr(18)));
-				}
-				break;
+				case "updateuser":
+					var nlIndex = data.indexOf("\n");
+					if (nlIndex > 0) {
+						this.receive(data.substr(nlIndex + 1));
+						parts = data.slice(1, nlIndex).split("|");
+					}
+					var parsed = BattleTextParser.parseNameParts(parts[1]);
+					var named = !!+parts[2];
 
-			case 'updatesearch':
-				if (this.rooms['']) {
-					this.rooms[''].updateSearch(JSON.parse(data.substr(14)));
-				}
-				break;
+					var userid = toUserid(parsed.name);
+					if (
+						userid === this.user.get("userid") &&
+						parsed.name !== this.user.get("name")
+					) {
+						$.post(
+							app.user.getActionPHP(),
+							{
+								act: "changeusername",
+								username: parsed.name,
+							},
+							function () {},
+							"text"
+						);
+					}
 
-			case 'popup':
-				var maxWidth;
-				var type = 'semimodal';
-				data = data.substr(7);
-				if (data.substr(0, 6) === '|wide|') {
-					data = data.substr(6);
-					maxWidth = 960;
-				}
-				if (data.substr(0, 7) === '|modal|') {
+					var settings = _.clone(app.user.get("settings"));
+					if (parts.length > 4) {
+						// Update our existing settings based on what the server has sent us.
+						// This approach is more robust as it works regardless of whether the
+						// server sends us all the values or just the diffs.
+						var update = JSON.parse(parts[4]);
+						for (var key in update) {
+							settings[key] = update[key];
+						}
+					}
+
+					this.user.set({
+						name: parsed.name,
+						userid: userid,
+						named: named,
+						avatar: parts[3],
+						settings: settings,
+						status: parsed.status,
+						away: parsed.away,
+					});
+					this.user.setPersistentName(named ? parsed.name : null);
+					if (named) {
+						this.trigger("init:choosename");
+					}
+					if (app.ignore[userid]) {
+						delete app.ignore[userid];
+						app.saveIgnore();
+					}
+					break;
+
+				case "nametaken":
+					app.addPopup(LoginPopup, {
+						name: parts[1] || "",
+						error: parts[2] || "",
+					});
+					break;
+
+				case "queryresponse":
+					var responseData = JSON.parse(data.substr(16 + parts[1].length));
+					app.trigger("response:" + parts[1], responseData);
+					break;
+
+				case "updatechallenges":
+					if (this.rooms[""]) {
+						this.rooms[""].updateChallenges(JSON.parse(data.substr(18)));
+					}
+					break;
+
+				case "updatesearch":
+					if (this.rooms[""]) {
+						this.rooms[""].updateSearch(JSON.parse(data.substr(14)));
+					}
+					break;
+
+				case "popup":
+					var maxWidth;
+					var type = "semimodal";
 					data = data.substr(7);
-					type = 'modal';
-				}
-				if (data.substr(0, 6) === '|html|') {
-					data = data.substr(6);
-					app.addPopup(Popup, {
-						type: type,
-						maxWidth: maxWidth,
-						htmlMessage: BattleLog.sanitizeHTML(data)
-					});
-				} else {
-					app.addPopup(Popup, {
-						type: type,
-						maxWidth: maxWidth,
-						message: data.replace(/\|\|/g, '\n')
-					});
-				}
-				if (this.rooms['']) this.rooms[''].resetPending();
-				break;
-
-			case 'disconnect':
-				app.trigger('init:socketclosed', BattleLog.sanitizeHTML(data.substr(12)));
-				break;
-
-			case 'pm':
-				var dataLines = data.split('\n');
-				for (var i = 0; i < dataLines.length; i++) {
-					parts = dataLines[i].slice(1).split('|');
-					var message = parts.slice(3).join('|');
-					this.rooms[''].addPM(parts[1], message, parts[2]);
-					if (toUserid(parts[1]) !== app.user.get('userid')) {
-						app.user.lastPM = toUserid(parts[1]);
+					if (data.substr(0, 6) === "|wide|") {
+						data = data.substr(6);
+						maxWidth = 960;
 					}
-				}
-				break;
-
-			case 'roomerror':
-				// deprecated; use |deinit| or |noinit|
-				this.unjoinRoom(parts[1]);
-				this.addPopupMessage(parts.slice(2).join('|'));
-				break;
-
-			case 'refresh':
-				// refresh the page
-				document.location.reload(true);
-				break;
-
-			case 'c':
-			case 'chat':
-				if (parts[1] === '~') {
-					if (parts[2].substr(0, 6) === '/warn ') {
-						app.addPopup(RulesPopup, {warning: parts[2].substr(6)});
-						break;
+					if (data.substr(0, 7) === "|modal|") {
+						data = data.substr(7);
+						type = "modal";
 					}
-				}
+					if (data.substr(0, 6) === "|html|") {
+						data = data.substr(6);
+						app.addPopup(Popup, {
+							type: type,
+							maxWidth: maxWidth,
+							htmlMessage: BattleLog.sanitizeHTML(data),
+						});
+					} else {
+						app.addPopup(Popup, {
+							type: type,
+							maxWidth: maxWidth,
+							message: data.replace(/\|\|/g, "\n"),
+						});
+					}
+					if (this.rooms[""]) this.rooms[""].resetPending();
+					break;
 
-			/* fall through */
-			default:
-				// the messagetype wasn't in our list of recognized global
-				// messagetypes; so the message is presumed to be for the
-				// lobby.
-				if (this.rooms['lobby']) {
-					this.rooms['lobby'].receive(data);
-				}
-				break;
+				case "disconnect":
+					app.trigger(
+						"init:socketclosed",
+						BattleLog.sanitizeHTML(data.substr(12))
+					);
+					break;
+
+				case "pm":
+					var dataLines = data.split("\n");
+					for (var i = 0; i < dataLines.length; i++) {
+						parts = dataLines[i].slice(1).split("|");
+						var message = parts.slice(3).join("|");
+						this.rooms[""].addPM(parts[1], message, parts[2]);
+						if (toUserid(parts[1]) !== app.user.get("userid")) {
+							app.user.lastPM = toUserid(parts[1]);
+						}
+					}
+					break;
+
+				case "roomerror":
+					// deprecated; use |deinit| or |noinit|
+					this.unjoinRoom(parts[1]);
+					this.addPopupMessage(parts.slice(2).join("|"));
+					break;
+
+				case "refresh":
+					// refresh the page
+					document.location.reload(true);
+					break;
+
+				case "c":
+				case "chat":
+					if (parts[1] === "~") {
+						if (parts[2].substr(0, 6) === "/warn ") {
+							app.addPopup(RulesPopup, { warning: parts[2].substr(6) });
+							break;
+						}
+					}
+
+				/* fall through */
+				default:
+					// the messagetype wasn't in our list of recognized global
+					// messagetypes; so the message is presumed to be for the
+					// lobby.
+					if (this.rooms["lobby"]) {
+						this.rooms["lobby"].receive(data);
+					}
+					break;
 			}
 		},
 		saveIgnore: function () {
-			Storage.prefs('ignorelist', Object.keys(this.ignore));
+			Storage.prefs("ignorelist", Object.keys(this.ignore));
 		},
 		loadIgnore: function () {
-			var ignoreList = Storage.prefs('ignorelist');
+			var ignoreList = Storage.prefs("ignorelist");
 			if (!ignoreList) return {};
 			var ignore = {};
 			for (var i = 0; i < ignoreList.length; i++) {
@@ -1233,17 +1594,20 @@ function toId() {
 				var entry = data[i];
 				if (!entry) continue;
 
-				var symbol = entry.symbol || ' ';
+				var symbol = entry.symbol || " ";
 				var groupName = entry.name;
-				var groupType = entry.type || 'user';
+				var groupType = entry.type || "user";
 
-				if (groupType === 'normal' && !Config.defaultOrder) Config.defaultOrder = i + 0.5; // this is where any undeclared groups will be positioned in userlist
+				if (groupType === "normal" && !Config.defaultOrder)
+					Config.defaultOrder = i + 0.5; // this is where any undeclared groups will be positioned in userlist
 				if (!groupName) Config.defaultGroup = symbol;
 
 				groups[symbol] = {
-					name: groupName ? BattleLog.escapeHTML(groupName + ' (' + symbol + ')') : null,
+					name: groupName
+						? BattleLog.escapeHTML(groupName + " (" + symbol + ")")
+						: null,
 					type: groupType,
-					order: i + 1
+					order: i + 1,
 				};
 			}
 
@@ -1251,20 +1615,24 @@ function toId() {
 		},
 		parseFormats: function (formatsList) {
 			var isSection = false;
-			var section = '';
+			var section = "";
 
 			var column = 0;
 			var columnChanged = false;
 
-			window.NonBattleGames = {rps: 'Rock Paper Scissors'};
+			window.NonBattleGames = { rps: "Rock Paper Scissors" };
 			window.BattleFormats = {};
 			for (var j = 1; j < formatsList.length; j++) {
 				if (isSection) {
 					section = formatsList[j];
 					isSection = false;
-				} else if (formatsList[j] === ',LL') {
+				} else if (formatsList[j] === ",LL") {
 					app.localLadder = true;
-				} else if (formatsList[j] === '' || (formatsList[j].charAt(0) === ',' && !isNaN(formatsList[j].substr(1)))) {
+				} else if (
+					formatsList[j] === "" ||
+					(formatsList[j].charAt(0) === "," &&
+						!isNaN(formatsList[j].substr(1)))
+				) {
 					isSection = true;
 
 					if (formatsList[j]) {
@@ -1282,11 +1650,14 @@ function toId() {
 					var partner = false;
 					var team = null;
 					var teambuilderLevel = null;
-					var lastCommaIndex = name.lastIndexOf(',');
-					var code = lastCommaIndex >= 0 ? parseInt(name.substr(lastCommaIndex + 1), 16) : NaN;
+					var lastCommaIndex = name.lastIndexOf(",");
+					var code =
+						lastCommaIndex >= 0
+							? parseInt(name.substr(lastCommaIndex + 1), 16)
+							: NaN;
 					if (!isNaN(code)) {
 						name = name.substr(0, lastCommaIndex);
-						if (code & 1) team = 'preset';
+						if (code & 1) team = "preset";
 						if (!(code & 2)) searchShow = false;
 						if (!(code & 4)) challengeShow = false;
 						if (!(code & 8)) tournamentShow = false;
@@ -1294,38 +1665,50 @@ function toId() {
 						if (code & 32) partner = true;
 					} else {
 						// Backwards compatibility: late 0.9.0 -> 0.10.0
-						if (name.substr(name.length - 2) === ',#') { // preset teams
-							team = 'preset';
+						if (name.substr(name.length - 2) === ",#") {
+							// preset teams
+							team = "preset";
 							name = name.substr(0, name.length - 2);
 						}
-						if (name.substr(name.length - 2) === ',,') { // search-only
+						if (name.substr(name.length - 2) === ",,") {
+							// search-only
 							challengeShow = false;
 							name = name.substr(0, name.length - 2);
-						} else if (name.substr(name.length - 1) === ',') { // challenge-only
+						} else if (name.substr(name.length - 1) === ",") {
+							// challenge-only
 							searchShow = false;
 							name = name.substr(0, name.length - 1);
 						}
 					}
 					var id = toID(name);
-					var isTeambuilderFormat = !team && name.slice(-11) !== 'Custom Game';
-					var teambuilderFormat = '';
-					var teambuilderFormatName = '';
+					var isTeambuilderFormat =
+						!team && name.slice(-11) !== "Custom Game";
+					var teambuilderFormat = "";
+					var teambuilderFormatName = "";
 					if (isTeambuilderFormat) {
 						teambuilderFormatName = name;
-						if (id.slice(0, 3) !== 'gen') {
-							teambuilderFormatName = '[Gen 6] ' + name;
+						if (id.slice(0, 3) !== "gen") {
+							teambuilderFormatName = "[Gen 6] " + name;
 						}
-						var parenPos = teambuilderFormatName.indexOf('(');
-						if (parenPos > 0 && name.slice(-1) === ')') {
+						var parenPos = teambuilderFormatName.indexOf("(");
+						if (parenPos > 0 && name.slice(-1) === ")") {
 							// variation of existing tier
-							teambuilderFormatName = $.trim(teambuilderFormatName.slice(0, parenPos));
+							teambuilderFormatName = $.trim(
+								teambuilderFormatName.slice(0, parenPos)
+							);
 						}
 						if (teambuilderFormatName !== name) {
 							teambuilderFormat = toID(teambuilderFormatName);
-							if (teambuilderFormat.startsWith('gen8nd')) teambuilderFormat = 'gen8nationaldex' + teambuilderFormat.slice(6);
-							if (teambuilderFormat.startsWith('gen8natdex')) teambuilderFormat = 'gen8nationaldex' + teambuilderFormat.slice(10);
+							if (teambuilderFormat.startsWith("gen8nd"))
+								teambuilderFormat =
+									"gen8nationaldex" + teambuilderFormat.slice(6);
+							if (teambuilderFormat.startsWith("gen8natdex"))
+								teambuilderFormat =
+									"gen8nationaldex" + teambuilderFormat.slice(10);
 							if (BattleFormats[teambuilderFormat]) {
-								BattleFormats[teambuilderFormat].isTeambuilderFormat = true;
+								BattleFormats[
+									teambuilderFormat
+								].isTeambuilderFormat = true;
 							} else {
 								BattleFormats[teambuilderFormat] = {
 									id: teambuilderFormat,
@@ -1335,7 +1718,7 @@ function toId() {
 									column: column,
 									rated: false,
 									isTeambuilderFormat: true,
-									effectType: 'Format'
+									effectType: "Format",
 								};
 							}
 							isTeambuilderFormat = false;
@@ -1355,12 +1738,12 @@ function toId() {
 						searchShow: searchShow,
 						challengeShow: challengeShow,
 						tournamentShow: tournamentShow,
-						rated: searchShow && id.substr(4, 7) !== 'unrated',
+						rated: searchShow && id.substr(4, 7) !== "unrated",
 						teambuilderLevel: teambuilderLevel,
 						partner: partner,
 						teambuilderFormat: teambuilderFormat,
 						isTeambuilderFormat: isTeambuilderFormat,
-						effectType: 'Format'
+						effectType: "Format",
 					};
 				}
 			}
@@ -1368,47 +1751,64 @@ function toId() {
 			// Match base formats to their variants, if they are unavailable in the server.
 			var multivariantFormats = {};
 			for (var id in BattleFormats) {
-				var teambuilderFormat = BattleFormats[BattleFormats[id].teambuilderFormat];
-				if (!teambuilderFormat || multivariantFormats[teambuilderFormat.id]) continue;
-				if (!teambuilderFormat.searchShow && !teambuilderFormat.challengeShow && !teambuilderFormat.tournamentShow) {
+				var teambuilderFormat =
+					BattleFormats[BattleFormats[id].teambuilderFormat];
+				if (!teambuilderFormat || multivariantFormats[teambuilderFormat.id])
+					continue;
+				if (
+					!teambuilderFormat.searchShow &&
+					!teambuilderFormat.challengeShow &&
+					!teambuilderFormat.tournamentShow
+				) {
 					// The base format is not available.
 					if (teambuilderFormat.battleFormat) {
 						multivariantFormats[teambuilderFormat.id] = 1;
-						teambuilderFormat.battleFormat = '';
+						teambuilderFormat.battleFormat = "";
 					} else {
 						teambuilderFormat.battleFormat = id;
 					}
 				}
 			}
-			if (columnChanged) app.supports['formatColumns'] = true;
-			this.trigger('init:formats');
+			if (columnChanged) app.supports["formatColumns"] = true;
+			this.trigger("init:formats");
 		},
 		uploadReplay: function (data) {
 			var id = data.id;
-			var serverid = Config.server.id && toID(Config.server.id.split(':')[0]);
+			var serverid =
+				Config.server.id && toID(Config.server.id.split(":")[0]);
 			var silent = data.silent;
-			if (serverid && serverid !== 'showdown') id = serverid + '-' + id;
-			$.post(app.user.getActionPHP(), {
-				act: 'uploadreplay',
-				log: data.log,
-				serverid: serverid,
-				password: data.password || '',
-				id: id
-			}, function (data) {
-				if (silent) return;
-				var sData = data.split(':');
-				if (sData[0] === 'success') {
-					app.addPopup(ReplayUploadedPopup, {id: sData[1] || id});
-				} else if (data === 'hash mismatch') {
-					app.addPopupMessage("Someone else is already uploading a replay of this battle. Try again in five seconds.");
-				} else if (data === 'not found') {
-					app.addPopupMessage("This server isn't registered, and doesn't support uploading replays.");
-				} else if (data === 'invalid id') {
-					app.addPopupMessage("This server is using invalid battle IDs, so this replay can't be uploaded.");
-				} else {
-					app.addPopupMessage("Error while uploading replay: " + data);
+			if (serverid && serverid !== "showdown") id = serverid + "-" + id;
+			$.post(
+				app.user.getActionPHP(),
+				{
+					act: "uploadreplay",
+					log: data.log,
+					serverid: serverid,
+					password: data.password || "",
+					id: id,
+				},
+				function (data) {
+					if (silent) return;
+					var sData = data.split(":");
+					if (sData[0] === "success") {
+						app.addPopup(ReplayUploadedPopup, { id: sData[1] || id });
+					} else if (data === "hash mismatch") {
+						app.addPopupMessage(
+							"Someone else is already uploading a replay of this battle. Try again in five seconds."
+						);
+					} else if (data === "not found") {
+						app.addPopupMessage(
+							"This server isn't registered, and doesn't support uploading replays."
+						);
+					} else if (data === "invalid id") {
+						app.addPopupMessage(
+							"This server is using invalid battle IDs, so this replay can't be uploaded."
+						);
+					} else {
+						app.addPopupMessage("Error while uploading replay: " + data);
+					}
 				}
-			});
+			);
 		},
 		roomsResponse: function (data) {
 			if (data) {
@@ -1417,29 +1817,41 @@ function toId() {
 			app.topbar.updateTabbar();
 		},
 		addGlobalListeners: function () {
-			$(document).on('click', 'a', function (e) {
-				if (this.className === 'closebutton') return; // handled elsewhere
-				if (this.className.indexOf('minilogo') >= 0) return; // handled elsewhere
+			$(document).on("click", "a", function (e) {
+				if (this.className === "closebutton") return; // handled elsewhere
+				if (this.className.indexOf("minilogo") >= 0) return; // handled elsewhere
 				if (!this.href) return; // should never happen
-				var isReplayLink = this.host === Config.routes.replays && Config.server.id === 'showdown';
-				if ((
-					isReplayLink || [Config.routes.client, 'psim.us', location.host].includes(this.host)
-				) && this.className !== 'no-panel-intercept') {
+				var isReplayLink =
+					this.host === Config.routes.replays &&
+					Config.server.id === "showdown";
+				if (
+					(isReplayLink ||
+						[Config.routes.client, "psim.us", location.host].includes(
+							this.host
+						)) &&
+					this.className !== "no-panel-intercept"
+				) {
 					if (!e.cmdKey && !e.metaKey && !e.ctrlKey) {
 						var target = this.pathname.substr(1);
-						var shortLinks = /^(rooms?suggestions?|suggestions?|adminrequests?|bugs?|bugreports?|rules?|faq|credits?|news|privacy|contact|dex|insecure|replays?|forgotpassword|devdiscord)$/;
-						if (target === 'appeal' || target === 'appeals') target = 'view-help-request--appeal';
-						if (target === 'report') target = 'view-help-request--report';
+						var shortLinks =
+							/^(rooms?suggestions?|suggestions?|adminrequests?|bugs?|bugreports?|rules?|faq|credits?|news|privacy|contact|dex|insecure|replays?|forgotpassword|devdiscord)$/;
+						if (target === "appeal" || target === "appeals")
+							target = "view-help-request--appeal";
+						if (target === "report") target = "view-help-request--report";
 						if (isReplayLink) {
-							if (!target || target === 'search') {
-								target = '.';
+							if (!target || target === "search") {
+								target = ".";
 							} else if (target.slice(0, 7) !== "battle-") {
-								target = 'battle-' + target;
+								target = "battle-" + target;
 							}
 						}
-						if (target.indexOf('/') < 0 && target.indexOf('.') < 0 && !shortLinks.test(target)) {
-							if (this.dataset && this.dataset.target === 'replace') {
-								var roomEl = $(this).closest('.ps-room')[0];
+						if (
+							target.indexOf("/") < 0 &&
+							target.indexOf(".") < 0 &&
+							!shortLinks.test(target)
+						) {
+							if (this.dataset && this.dataset.target === "replace") {
+								var roomEl = $(this).closest(".ps-room")[0];
 								if (roomEl && roomEl.id) {
 									var roomid = roomEl.id.slice(5);
 									window.app.renameRoom(roomid, target);
@@ -1457,21 +1869,24 @@ function toId() {
 						}
 					}
 				}
-				if (window.nodewebkit && this.target === '_blank') {
+				if (window.nodewebkit && this.target === "_blank") {
 					gui.Shell.openExternal(this.href);
 					e.preventDefault();
 					e.stopPropagation();
 					e.stopImmediatePropagation();
 					return;
 				}
-				if (this.rel === 'noopener') {
-					var formatOptions = Dex.prefs('chatformatting') || {};
-					if (!formatOptions.hideinterstice && !BattleLog.interstice.isWhitelisted(this.href)) {
+				if (this.rel === "noopener") {
+					var formatOptions = Dex.prefs("chatformatting") || {};
+					if (
+						!formatOptions.hideinterstice &&
+						!BattleLog.interstice.isWhitelisted(this.href)
+					) {
 						this.href = BattleLog.interstice.getURI(this.href);
 					}
-				} else if (this.target === '_blank') {
+				} else if (this.target === "_blank") {
 					// for performance reasons, there's no reason to ever have an opener
-					this.rel = 'noopener';
+					this.rel = "noopener";
 				}
 			});
 		},
@@ -1485,23 +1900,32 @@ function toId() {
 			this.roomList = [];
 			this.sideRoomList = [];
 
-			$(window).on('resize', _.bind(this.resize, this));
+			$(window).on("resize", _.bind(this.resize, this));
 		},
 		fixedWidth: true,
 		resize: function () {
 			if (window.screen && screen.width && screen.width >= 320) {
 				if (this.fixedWidth) {
-					document.getElementById('viewport').setAttribute('content', 'width=device-width');
+					document
+						.getElementById("viewport")
+						.setAttribute("content", "width=device-width");
 					this.fixedWidth = false;
 				}
 			} else {
 				if (!this.fixedWidth) {
-					document.getElementById('viewport').setAttribute('content', 'width=320');
+					document
+						.getElementById("viewport")
+						.setAttribute("content", "width=320");
 					this.fixedWidth = true;
 				}
 			}
-			if (!app.roomsFirstOpen && !this.down && $(window).width() >= 916 && document.location.hostname === Config.routes.client) {
-				this.addRoom('rooms');
+			if (
+				!app.roomsFirstOpen &&
+				!this.down &&
+				$(window).width() >= 916 &&
+				document.location.hostname === Config.routes.client
+			) {
+				this.addRoom("rooms");
 			}
 			this.updateLayout();
 		},
@@ -1515,7 +1939,8 @@ function toId() {
 				if (this.rooms[id].rejoin) this.rooms[id].rejoin();
 				return this.rooms[id];
 			}
-			if (id.substr(0, 11) === 'battle-gen5' && !Dex.loadedSpriteData['bw']) Dex.loadSpriteData('bw');
+			if (id.substr(0, 11) === "battle-gen5" && !Dex.loadedSpriteData["bw"])
+				Dex.loadSpriteData("bw");
 
 			var room = this._addRoom(id, type, nojoin);
 			this.focusRoom(id);
@@ -1526,7 +1951,7 @@ function toId() {
 		 */
 		unjoinRoom: function (id, reason) {
 			this.removeRoom(id, true);
-			if (this.curRoom) this.navigate(this.curRoom.id, {replace: true});
+			if (this.curRoom) this.navigate(this.curRoom.id, { replace: true });
 			this.updateAutojoin();
 		},
 		tryJoinRoom: function (id) {
@@ -1557,29 +1982,31 @@ function toId() {
 
 			var el;
 			if (!id) {
-				el = $('#mainmenu');
+				el = $("#mainmenu");
 			} else {
-				el = $('<div class="ps-room" style="display:none"></div>').appendTo('body');
+				el = $('<div class="ps-room" style="display:none"></div>').appendTo(
+					"body"
+				);
 			}
-			var typeName = '';
-			if (typeof type === 'string') {
+			var typeName = "";
+			if (typeof type === "string") {
 				typeName = type;
 				type = null;
 			}
 			var roomTable = {
-				'': MainMenuRoom,
-				'teambuilder': TeambuilderRoom,
-				'rooms': RoomsRoom,
-				'battles': BattlesRoom,
-				'ladder': LadderRoom,
-				'lobby': ChatRoom,
-				'staff': ChatRoom,
-				'constructor': ChatRoom
+				"": MainMenuRoom,
+				teambuilder: TeambuilderRoom,
+				rooms: RoomsRoom,
+				battles: BattlesRoom,
+				ladder: LadderRoom,
+				lobby: ChatRoom,
+				staff: ChatRoom,
+				constructor: ChatRoom,
 			};
 			var typeTable = {
-				'html': HTMLRoom,
-				'battle': BattleRoom,
-				'chat': ChatRoom
+				html: HTMLRoom,
+				battle: BattleRoom,
+				chat: ChatRoom,
 			};
 
 			// the passed type overrides everything else
@@ -1590,27 +2017,27 @@ function toId() {
 
 			// otherwise, infer the room type
 			if (!type) {
-				if (id.startsWith('battle-') || id.startsWith('game-')) {
+				if (id.startsWith("battle-") || id.startsWith("game-")) {
 					type = BattleRoom;
-				} else if (id.startsWith('view-')) {
+				} else if (id.startsWith("view-")) {
 					type = HTMLRoom;
 				} else {
 					type = ChatRoom;
 				}
 			}
 
-			var room = this.rooms[id] = new type({
+			var room = (this.rooms[id] = new type({
 				id: id,
 				el: el,
 				nojoin: nojoin,
-				title: title
-			});
+				title: title,
+			}));
 			if (oldRoom) {
 				if (this.curRoom === oldRoom) this.curRoom = room;
 				if (this.curSideRoom === oldRoom) this.curSideRoom = room;
 				if (this.sideRoom === oldRoom) this.sideRoom = room;
 			}
-			if (['', 'teambuilder', 'ladder', 'rooms'].indexOf(room.id) < 0) {
+			if (["", "teambuilder", "ladder", "rooms"].indexOf(room.id) < 0) {
 				if (room.isSideRoom) {
 					this.sideRoomList.push(room);
 				} else {
@@ -1634,8 +2061,8 @@ function toId() {
 				if (this.curRoom) {
 					this.curRoom.hide();
 					this.curRoom = null;
-				} else if (this.rooms['']) {
-					this.rooms[''].hide();
+				} else if (this.rooms[""]) {
+					this.rooms[""].hide();
 				}
 				this.curRoom = window.room = room;
 				this.updateLayout();
@@ -1665,8 +2092,8 @@ function toId() {
 			if (this.curRoom) {
 				this.curRoom.hide();
 				this.curRoom = null;
-			} else if (this.rooms['']) {
-				this.rooms[''].hide();
+			} else if (this.rooms[""]) {
+				this.rooms[""].hide();
 			}
 			this.curRoom = room;
 			this.updateLayout();
@@ -1684,7 +2111,8 @@ function toId() {
 			}
 
 			if (this.curRoom === room) {
-				this.curRoom = this.roomList[this.roomList.length - 1] || this.rooms[''];
+				this.curRoom =
+					this.roomList[this.roomList.length - 1] || this.rooms[""];
 			}
 
 			room.isSideRoom = true;
@@ -1709,16 +2137,16 @@ function toId() {
 			// room in full. Home is a left room, so we'll always have a
 			// left room.
 			if (!this.sideRoom || this.singlePanelMode) {
-				this.curRoom.show('full');
+				this.curRoom.show("full");
 				if (this.curSideRoom) {
 					this.curSideRoom.hide();
 					this.curSideRoom = null;
 				}
-				if (this.curRoom.id === '') {
+				if (this.curRoom.id === "") {
 					if ($(window).width() < this.curRoom.bestWidth) {
-						this.curRoom.$el.addClass('tiny-layout');
+						this.curRoom.$el.addClass("tiny-layout");
 					} else {
-						this.curRoom.$el.removeClass('tiny-layout');
+						this.curRoom.$el.removeClass("tiny-layout");
 					}
 				}
 				this.topbar.updateTabbar();
@@ -1727,18 +2155,18 @@ function toId() {
 
 			// The rest of this code assumes we have a right room (sideRoom)
 
-			var leftMin = (this.curRoom.minWidth || this.curRoom.bestWidth);
-			var leftMinMain = (this.curRoom.minMainWidth || leftMin);
-			var rightMin = (this.sideRoom.minWidth || this.sideRoom.bestWidth);
+			var leftMin = this.curRoom.minWidth || this.curRoom.bestWidth;
+			var leftMinMain = this.curRoom.minMainWidth || leftMin;
+			var rightMin = this.sideRoom.minWidth || this.sideRoom.bestWidth;
 			var available = $(window).width();
 			if (this.curRoom.isSideRoom) {
 				// we're trying to focus a side room
-				if (available >= this.rooms[''].tinyWidth + leftMinMain) {
+				if (available >= this.rooms[""].tinyWidth + leftMinMain) {
 					// it fits to the right of the main menu, so do that
 					this.curSideRoom = this.sideRoom = this.curRoom;
-					this.curRoom = this.rooms[''];
+					this.curRoom = this.rooms[""];
 					leftMin = this.curRoom.tinyWidth;
-					rightMin = (this.sideRoom.minWidth || this.sideRoom.bestWidth);
+					rightMin = this.sideRoom.minWidth || this.sideRoom.bestWidth;
 				} else if (this.sideRoom) {
 					// nooo, doesn't fit
 					// show the side room in full
@@ -1746,11 +2174,11 @@ function toId() {
 						this.curSideRoom.hide();
 						this.curSideRoom = null;
 					}
-					this.curRoom.show('full');
+					this.curRoom.show("full");
 					this.topbar.updateTabbar();
 					return;
 				}
-			} else if (this.curRoom.id === '') {
+			} else if (this.curRoom.id === "") {
 				leftMin = this.curRoom.tinyWidth;
 				leftMinMain = leftMin;
 			}
@@ -1766,11 +2194,11 @@ function toId() {
 					this.curSideRoom = null;
 				}
 				if ($(window).width() < this.curRoom.bestWidth) {
-					this.curRoom.$el.addClass('tiny-layout');
+					this.curRoom.$el.addClass("tiny-layout");
 				} else {
-					this.curRoom.$el.removeClass('tiny-layout');
+					this.curRoom.$el.removeClass("tiny-layout");
 				}
-				this.curRoom.show('full');
+				this.curRoom.show("full");
 				this.topbar.updateTabbar();
 				return;
 			}
@@ -1779,14 +2207,14 @@ function toId() {
 			if (leftMin === this.curRoom.tinyWidth) {
 				if (available < this.curRoom.bestWidth + 570) {
 					// there's only room for the tiny layout :(
-					this.curRoom.show('left', leftMin);
-					this.curRoom.$el.addClass('tiny-layout');
-					this.curSideRoom.show('right', leftMin);
+					this.curRoom.show("left", leftMin);
+					this.curRoom.$el.addClass("tiny-layout");
+					this.curSideRoom.show("right", leftMin);
 					this.topbar.updateTabbar();
 					return;
 				}
-				leftMin = (this.curRoom.minWidth || this.curRoom.bestWidth);
-				this.curRoom.$el.removeClass('tiny-layout');
+				leftMin = this.curRoom.minWidth || this.curRoom.bestWidth;
+				this.curRoom.$el.removeClass("tiny-layout");
 			}
 
 			// Formula for calculating exactly how much width the left and
@@ -1798,27 +2226,33 @@ function toId() {
 			// room's isn't. All rooms need to handle any width at all;
 			// maxWidth applies only to left rooms.
 
-			var leftMax = (this.curRoom.maxWidth || this.curRoom.bestWidth);
-			var rightMax = (this.sideRoom.maxWidth || this.sideRoom.bestWidth);
+			var leftMax = this.curRoom.maxWidth || this.curRoom.bestWidth;
+			var rightMax = this.sideRoom.maxWidth || this.sideRoom.bestWidth;
 			var leftWidth = leftMin;
 			if (leftMax + rightMax <= available) {
 				leftWidth = leftMax;
 			} else {
 				var bufAvailable = available - leftMin - rightMin;
 				var wanted = leftMax - leftMin + rightMax - rightMin;
-				if (wanted > 0) leftWidth = Math.floor(leftMin + (leftMax - leftMin) * bufAvailable / wanted);
+				if (wanted > 0)
+					leftWidth = Math.floor(
+						leftMin + ((leftMax - leftMin) * bufAvailable) / wanted
+					);
 			}
 			if (leftWidth < leftMinMain) {
 				leftWidth = leftMinMain;
 			}
-			if (this.curRoom.type === 'battle' && this.sideRoom.type !== 'battle') {
+			if (
+				this.curRoom.type === "battle" &&
+				this.sideRoom.type !== "battle"
+			) {
 				// I give up; hardcoding
 				var offset = Math.floor((available - leftMinMain - rightMin) / 2);
 				if (offset > 0) leftWidth += offset;
 				if (leftWidth > leftMax) leftWidth = leftMax;
 			}
-			this.curRoom.show('left', leftWidth);
-			this.curSideRoom.show('right', leftWidth);
+			this.curRoom.show("left", leftWidth);
+			this.curSideRoom.show("right", leftWidth);
 			this.topbar.updateTabbar();
 		},
 		updateSideRoom: function (id) {
@@ -1855,7 +2289,7 @@ function toId() {
 			room.id = newid;
 			if (room.battle) room.battle.roomid = newid;
 			room.title = newtitle;
-			room.$el[0].id = 'room-' + newid;
+			room.$el[0].id = "room-" + newid;
 			this.rooms[newid] = room;
 			delete this.rooms[id];
 			this.updateLayout();
@@ -1868,7 +2302,7 @@ function toId() {
 		removeRoom: function (id, alreadyLeft) {
 			var room = this.rooms[id];
 			if (!room) return false;
-			if (room === this.curRoom) this.focusRoom('');
+			if (room === this.curRoom) this.focusRoom("");
 			delete this.rooms[id];
 			var index = this.roomList.indexOf(room);
 			if (index >= 0) this.roomList.splice(index, 1);
@@ -1898,7 +2332,7 @@ function toId() {
 					this.topbar.updateTabbar();
 				}
 				room.focusText();
-				if (room.type === 'chat') this.updateAutojoin();
+				if (room.type === "chat") this.updateAutojoin();
 				return true;
 			}
 			index = this.sideRoomList.indexOf(room);
@@ -1915,7 +2349,7 @@ function toId() {
 					this.topbar.updateTabbar();
 				}
 				room.focusText();
-				if (room.type === 'chat') this.updateAutojoin();
+				if (room.type === "chat") this.updateAutojoin();
 				return true;
 			}
 			return false;
@@ -1923,16 +2357,19 @@ function toId() {
 		focusRoomBy: function (room, amount, focusTextbox) {
 			this.arrowKeysUsed = true;
 			var rooms = this.roomList.concat(this.sideRoomList);
-			if (room && room.id === 'rooms') {
+			if (room && room.id === "rooms") {
 				if (!rooms.length) return false;
-				this.focusRoom(rooms[amount < 0 ? rooms.length - 1 : 0].id, focusTextbox);
+				this.focusRoom(
+					rooms[amount < 0 ? rooms.length - 1 : 0].id,
+					focusTextbox
+				);
 				return true;
 			}
 			var index = rooms.indexOf(room);
 			if (index >= 0) {
 				var newIndex = index + amount;
 				if (!rooms[newIndex]) {
-					this.joinRoom('rooms');
+					this.joinRoom("rooms");
 					return true;
 				}
 				this.focusRoom(rooms[newIndex].id, focusTextbox);
@@ -1944,7 +2381,7 @@ function toId() {
 			if (window.nodewebkit) {
 				gui.Shell.openExternal(url);
 			} else {
-				window.open(url, '_blank');
+				window.open(url, "_blank");
 			}
 		},
 		clickLink: function (e) {
@@ -1957,7 +2394,9 @@ function toId() {
 			if (room.id === this.fragment) this.updateTitle(room);
 		},
 		updateTitle: function (room) {
-			document.title = room.title ? room.title + " - Showdown!" : "Showdown!";
+			document.title = room.title
+				? room.title + " - Showdown!"
+				: "Showdown!";
 		},
 		updateAutojoin: function () {
 			if (!Config.server.registered) return;
@@ -1966,45 +2405,55 @@ function toId() {
 			var rooms = this.roomList.concat(this.sideRoomList);
 			for (var i = 0; i < rooms.length; i++) {
 				var room = rooms[i];
-				if (room.type !== 'chat') continue;
-				autojoins.push(room.id.indexOf('-') >= 0 ? room.id : (room.title || room.id));
-				if (room.id === 'staff' || room.id === 'upperstaff' || (Config.server.id !== 'showdown' && room.id === 'lobby')) continue;
+				if (room.type !== "chat") continue;
+				autojoins.push(
+					room.id.indexOf("-") >= 0 ? room.id : room.title || room.id
+				);
+				if (
+					room.id === "staff" ||
+					room.id === "upperstaff" ||
+					(Config.server.id !== "showdown" && room.id === "lobby")
+				)
+					continue;
 				autojoinCount++;
 				if (autojoinCount >= 15) break;
 			}
-			var curAutojoin = (Dex.prefs('autojoin') || '');
-			if (typeof curAutojoin !== 'string') {
-				if (curAutojoin[Config.server.id] === autojoins.join(',')) return;
+			var curAutojoin = Dex.prefs("autojoin") || "";
+			if (typeof curAutojoin !== "string") {
+				if (curAutojoin[Config.server.id] === autojoins.join(",")) return;
 				if (!autojoins.length) {
 					delete curAutojoin[Config.server.id];
 					// If the only key left is 'showdown', revert to the string method for storing autojoin.
 					var hasSideServer = false;
 					for (var key in curAutojoin) {
-						if (key === 'showdown') continue;
+						if (key === "showdown") continue;
 						hasSideServer = true;
 						break;
 					}
-					if (!hasSideServer) curAutojoin = curAutojoin.showdown || '';
+					if (!hasSideServer) curAutojoin = curAutojoin.showdown || "";
 				} else {
-					curAutojoin[Config.server.id] = autojoins.join(',');
+					curAutojoin[Config.server.id] = autojoins.join(",");
 				}
 			} else {
-				if (Config.server.id !== 'showdown') {
+				if (Config.server.id !== "showdown") {
 					// Switch to the autojoin object to handle multiple servers
-					curAutojoin = {showdown: curAutojoin};
+					curAutojoin = { showdown: curAutojoin };
 					if (!autojoins.length) return;
-					curAutojoin[Config.server.id] = autojoins.join(',');
+					curAutojoin[Config.server.id] = autojoins.join(",");
 				} else {
-					if (curAutojoin === autojoins.join(',')) return;
-					curAutojoin = autojoins.join(',');
+					if (curAutojoin === autojoins.join(",")) return;
+					curAutojoin = autojoins.join(",");
 				}
 			}
-			Storage.prefs('autojoin', curAutojoin);
+			Storage.prefs("autojoin", curAutojoin);
 		},
 
 		playNotificationSound: function () {
-			if (window.BattleSound && !Dex.prefs('mute')) {
-				BattleSound.playSound('audio/notification.wav', Dex.prefs('notifvolume'));
+			if (window.BattleSound && !Dex.prefs("mute")) {
+				BattleSound.playSound(
+					"audio/notification.wav",
+					Dex.prefs("notifvolume")
+				);
 			}
 		},
 
@@ -2026,7 +2475,11 @@ function toId() {
 			if (data.sourcePopup === undefined && app.dispatchingPopup) {
 				data.sourcePopup = app.dispatchingPopup;
 			}
-			if (this.dismissingSource && $(data.sourceEl)[0] === this.dismissingSource) return;
+			if (
+				this.dismissingSource &&
+				$(data.sourceEl)[0] === this.dismissingSource
+			)
+				return;
 			while (this.popups.length) {
 				var prevPopup = this.popups[this.popups.length - 1];
 				if (data.sourcePopup === prevPopup) {
@@ -2043,12 +2496,14 @@ function toId() {
 			popup.lastFocusedEl = document.activeElement;
 
 			var $overlay;
-			if (popup.type === 'normal') {
-				$('body').append(popup.el);
+			if (popup.type === "normal") {
+				$("body").append(popup.el);
 			} else {
-				$overlay = $('<div class="ps-overlay"></div>').appendTo('body').append(popup.el);
-				if (popup.type === 'semimodal') {
-					$overlay.on('click', function (e) {
+				$overlay = $('<div class="ps-overlay"></div>')
+					.appendTo("body")
+					.append(popup.el);
+				if (popup.type === "semimodal") {
+					$overlay.on("click", function (e) {
 						if (e.currentTarget === e.target) {
 							popup.close();
 						}
@@ -2057,7 +2512,7 @@ function toId() {
 			}
 
 			if (popup.domInitialize) popup.domInitialize(data);
-			popup.$('.autofocus').select().focus();
+			popup.$(".autofocus").select().focus();
 			if ($overlay) $overlay.scrollTop(0);
 			this.popups.push(popup);
 			return popup;
@@ -2065,19 +2520,27 @@ function toId() {
 		addPopupMessage: function (message) {
 			// shorthand for adding a popup message
 			// this is the equivalent of alert(message)
-			app.addPopup(Popup, {message: message});
+			app.addPopup(Popup, { message: message });
 		},
 		addPopupPrompt: function (message, buttonOrCallback, callback) {
-			var button = (callback ? buttonOrCallback : 'OK');
-			callback = (!callback ? buttonOrCallback : callback);
-			app.addPopup(PromptPopup, {message: message, button: button, callback: callback});
+			var button = callback ? buttonOrCallback : "OK";
+			callback = !callback ? buttonOrCallback : callback;
+			app.addPopup(PromptPopup, {
+				message: message,
+				button: button,
+				callback: callback,
+			});
 		},
 		closePopup: function (id) {
 			if (this.popups.length) {
 				var popup = this.popups.pop();
-				if (popup.lastFocusedEl && popup.lastFocusedEl.focus) popup.lastFocusedEl.focus();
+				if (popup.lastFocusedEl && popup.lastFocusedEl.focus)
+					popup.lastFocusedEl.focus();
 				popup.remove();
-				if (this.reconnectPending) this.addPopup(ReconnectPopup, {message: this.reconnectPending});
+				if (this.reconnectPending)
+					this.addPopup(ReconnectPopup, {
+						message: this.reconnectPending,
+					});
 				return true;
 			}
 			return false;
@@ -2086,28 +2549,29 @@ function toId() {
 			var source = false;
 			while (this.popups.length) {
 				var popup = this.popups[this.popups.length - 1];
-				if (popup.type !== 'normal') return source;
+				if (popup.type !== "normal") return source;
 				if (popup.sourceEl) source = popup.sourceEl[0];
 				if (!source) source = true;
 				this.popups.pop().remove();
 			}
 			return source;
-		}
-
+		},
 	});
 
 	this.Room = Backbone.View.extend({
-		className: 'ps-room',
+		className: "ps-room",
 		constructor: function (options) {
 			if (!this.events) this.events = {};
-			if (!this.events['click button']) this.events['click button'] = 'dispatchClickButton';
-			if (!this.events['click']) this.events['click'] = 'dispatchClickBackground';
+			if (!this.events["click button"])
+				this.events["click button"] = "dispatchClickButton";
+			if (!this.events["click"])
+				this.events["click"] = "dispatchClickBackground";
 
 			Backbone.View.apply(this, arguments);
 
 			if (!(options && options.nojoin)) this.join();
 			if (options && options.title) this.title = options.title;
-			this.el.id = 'room-' + this.id;
+			this.el.id = "room-" + this.id;
 		},
 		dispatchClickButton: function (e) {
 			var target = e.currentTarget;
@@ -2123,7 +2587,10 @@ function toId() {
 		},
 		dispatchClickBackground: function (e) {
 			app.dismissPopups();
-			if (e.shiftKey || (window.getSelection && !window.getSelection().isCollapsed)) {
+			if (
+				e.shiftKey ||
+				(window.getSelection && !window.getSelection().isCollapsed)
+			) {
 				return;
 			}
 			this.focus(e);
@@ -2150,16 +2617,16 @@ function toId() {
 		show: function (position, leftWidth) {
 			this.leftWidth = 0;
 			switch (position) {
-			case 'left':
-				this.$el.css({left: 0, width: leftWidth, right: 'auto'});
-				break;
-			case 'right':
-				this.$el.css({left: leftWidth + 1, width: 'auto', right: 0});
-				this.leftWidth = leftWidth;
-				break;
-			case 'full':
-				this.$el.css({left: 0, width: 'auto', right: 0});
-				break;
+				case "left":
+					this.$el.css({ left: 0, width: leftWidth, right: "auto" });
+					break;
+				case "right":
+					this.$el.css({ left: leftWidth + 1, width: "auto", right: 0 });
+					this.leftWidth = leftWidth;
+					break;
+				case "full":
+					this.$el.css({ left: 0, width: "auto", right: 0 });
+					break;
 			}
 			this.$el.show();
 			this.dismissAllNotifications(true);
@@ -2177,7 +2644,10 @@ function toId() {
 
 		requestNotifications: function () {
 			try {
-				if (window.webkitNotifications && webkitNotifications.requestPermission) {
+				if (
+					window.webkitNotifications &&
+					webkitNotifications.requestPermission
+				) {
 					// Notification.requestPermission crashes Chrome 23:
 					//   https://code.google.com/p/chromium/issues/detail?id=139594
 					// In lieu of a way to detect Chrome 23, we'll just use the old
@@ -2189,12 +2659,17 @@ function toId() {
 				}
 			} catch (e) {}
 		},
-		notificationClass: '',
+		notificationClass: "",
 		notifications: null,
 		subtleNotification: false,
 		notify: function (title, body, tag, once) {
-			if (once && app.focused && (this === app.curRoom || this == app.curSideRoom)) return;
-			if (!tag) tag = 'message';
+			if (
+				once &&
+				app.focused &&
+				(this === app.curRoom || this == app.curSideRoom)
+			)
+				return;
+			if (!tag) tag = "message";
 			var needsTabbarUpdate = false;
 			if (!this.notifications) {
 				this.notifications = {};
@@ -2210,11 +2685,14 @@ function toId() {
 				// old one doesn't need to be closed; sending the tag should
 				// automatically replace the old notification
 				try {
-					var notification = this.notifications[tag] = new Notification(title, {
-						lang: 'en',
-						body: body,
-						tag: this.id + ':' + tag
-					});
+					var notification = (this.notifications[tag] = new Notification(
+						title,
+						{
+							lang: "en",
+							body: body,
+							tag: this.id + ":" + tag,
+						}
+					));
 					var self = this;
 					notification.onclose = function () {
 						self.dismissNotification(tag);
@@ -2223,11 +2701,15 @@ function toId() {
 						window.focus();
 						self.clickNotification(tag);
 					};
-					if (Dex.prefs('temporarynotifications')) {
+					if (Dex.prefs("temporarynotifications")) {
 						if (notification.cancel) {
-							setTimeout(function () {notification.cancel();}, 5000);
+							setTimeout(function () {
+								notification.cancel();
+							}, 5000);
 						} else if (notification.close) {
-							setTimeout(function () {notification.close();}, 5000);
+							setTimeout(function () {
+								notification.close();
+							}, 5000);
 						}
 					}
 					if (once) notification.psAutoclose = true;
@@ -2238,7 +2720,7 @@ function toId() {
 			} else if (window.macgap) {
 				macgap.growl.notify({
 					title: title,
-					content: body
+					content: body,
 				});
 				var notification = {};
 				this.notifications[tag] = notification;
@@ -2249,15 +2731,16 @@ function toId() {
 				if (once) notification.psAutoclose = true;
 			}
 			if (needsTabbarUpdate) {
-				this.notificationClass = ' notifying';
+				this.notificationClass = " notifying";
 				app.topbar.updateTabbar();
 			}
 		},
 		subtleNotifyOnce: function () {
-			if (app.focused && (this === app.curRoom || this == app.curSideRoom)) return;
+			if (app.focused && (this === app.curRoom || this == app.curSideRoom))
+				return;
 			if (this.notifications || this.subtleNotification) return;
 			this.subtleNotification = true;
-			this.notificationClass = ' subtle-notifying';
+			this.notificationClass = " subtle-notifying";
 			app.topbar.updateTabbar();
 		},
 		notifyOnce: function (title, body, tag) {
@@ -2279,7 +2762,9 @@ function toId() {
 			delete this.notifications[tag];
 			if (_.isEmpty(this.notifications)) {
 				this.notifications = null;
-				this.notificationClass = (this.subtleNotification ? ' subtle-notifying' : '');
+				this.notificationClass = this.subtleNotification
+					? " subtle-notifying"
+					: "";
 				app.topbar.updateTabbar();
 			}
 		},
@@ -2298,7 +2783,7 @@ function toId() {
 				}
 				this.notifications = null;
 			}
-			this.notificationClass = '';
+			this.notificationClass = "";
 			if (skipUpdate) return;
 			app.topbar.updateTabbar();
 		},
@@ -2315,7 +2800,9 @@ function toId() {
 				delete this.notifications[tag];
 				if (!this.notifications || _.isEmpty(this.notifications)) {
 					this.notifications = null;
-					this.notificationClass = (this.subtleNotification ? ' subtle-notifying' : '');
+					this.notificationClass = this.subtleNotification
+						? " subtle-notifying"
+						: "";
 					app.topbar.updateTabbar();
 				}
 			} else {
@@ -2324,8 +2811,11 @@ function toId() {
 
 			if (this.lastMessageDate) {
 				// Mark chat messages as read to avoid double-notifying on reload
-				var lastMessageDates = Dex.prefs('logtimes') || (Storage.prefs('logtimes', {}), Dex.prefs('logtimes'));
-				if (!lastMessageDates[Config.server.id]) lastMessageDates[Config.server.id] = {};
+				var lastMessageDates =
+					Dex.prefs("logtimes") ||
+					(Storage.prefs("logtimes", {}), Dex.prefs("logtimes"));
+				if (!lastMessageDates[Config.server.id])
+					lastMessageDates[Config.server.id] = {};
 				lastMessageDates[Config.server.id][this.id] = this.lastMessageDate;
 				Storage.prefs.save();
 			}
@@ -2350,14 +2840,17 @@ function toId() {
 				}
 			}
 			if (!this.notifications) {
-				this.notificationClass = '';
+				this.notificationClass = "";
 				if (!skipUpdate) app.topbar.updateTabbar();
 			}
 
 			if (this.lastMessageDate) {
 				// Mark chat messages as read to avoid double-notifying on reload
-				var lastMessageDates = Dex.prefs('logtimes') || (Storage.prefs('logtimes', {}), Dex.prefs('logtimes'));
-				if (!lastMessageDates[Config.server.id]) lastMessageDates[Config.server.id] = {};
+				var lastMessageDates =
+					Dex.prefs("logtimes") ||
+					(Storage.prefs("logtimes", {}), Dex.prefs("logtimes"));
+				if (!lastMessageDates[Config.server.id])
+					lastMessageDates[Config.server.id] = {};
 				lastMessageDates[Config.server.id][this.id] = this.lastMessageDate;
 				Storage.prefs.save();
 			}
@@ -2377,11 +2870,10 @@ function toId() {
 			if (!alreadyLeft) this.leave();
 			this.remove();
 			delete this.app;
-		}
+		},
 	});
 
-	var Popup = this.Popup = Backbone.View.extend({
-
+	var Popup = (this.Popup = Backbone.View.extend({
 		// If type is 'modal', background will turn gray and popup won't be
 		// dismissible except by interacting with it.
 		// If type is 'semimodal', background will turn gray, but clicking
@@ -2389,13 +2881,15 @@ function toId() {
 		// Otherwise, background won't change, and interacting with anything
 		// other than the popup will still be possible (and will dismiss
 		// the popup).
-		type: 'normal',
+		type: "normal",
 
-		className: 'ps-popup',
+		className: "ps-popup",
 		constructor: function (data) {
 			if (!this.events) this.events = {};
-			if (!this.events['click button']) this.events['click button'] = 'dispatchClickButton';
-			if (!this.events['submit form']) this.events['submit form'] = 'dispatchSubmit';
+			if (!this.events["click button"])
+				this.events["click button"] = "dispatchClickButton";
+			if (!this.events["submit form"])
+				this.events["submit form"] = "dispatchSubmit";
 			if (data && data.sourceEl) {
 				this.sourceEl = data.sourceEl = $(data.sourceEl);
 			}
@@ -2407,15 +2901,22 @@ function toId() {
 			Backbone.View.apply(this, arguments);
 
 			// if we have no source, we can't attach to anything
-			if (this.type === 'normal' && !this.sourceEl) this.type = 'semimodal';
+			if (this.type === "normal" && !this.sourceEl) this.type = "semimodal";
 
-			if ((this.type === 'normal' || this.type === 'semimodal') && this.sourceEl) {
+			if (
+				(this.type === "normal" || this.type === "semimodal") &&
+				this.sourceEl
+			) {
 				// nonmodal popup: should be positioned near source element
 				var $el = this.$el;
-				var $measurer = $('<div style="position:relative;height:0;overflow:hidden"></div>').appendTo('body').append($el);
-				$el.css('position', 'absolute');
-				$el.css('margin', '0');
-				$el.css('width', this.width - 22);
+				var $measurer = $(
+					'<div style="position:relative;height:0;overflow:hidden"></div>'
+				)
+					.appendTo("body")
+					.append($el);
+				$el.css("position", "absolute");
+				$el.css("margin", "0");
+				$el.css("width", this.width - 22);
 
 				var offset = this.sourceEl.offset();
 
@@ -2424,41 +2925,45 @@ function toId() {
 				var width = $el.outerWidth();
 				var sourceHeight = this.sourceEl.outerHeight();
 
-				if (this.position === 'right') {
-
-					if (room > offset.top + height + 5 &&
-						(offset.top < room * 2 / 3 || offset.top + 200 < room)) {
-						$el.css('top', offset.top);
+				if (this.position === "right") {
+					if (
+						room > offset.top + height + 5 &&
+						(offset.top < (room * 2) / 3 || offset.top + 200 < room)
+					) {
+						$el.css("top", offset.top);
 					} else {
-						$el.css('bottom', Math.max(room - offset.top - sourceHeight, 0));
+						$el.css(
+							"bottom",
+							Math.max(room - offset.top - sourceHeight, 0)
+						);
 					}
 					var offsetLeft = offset.left + this.sourceEl.outerWidth();
 					if (offsetLeft + width > $(window).width()) {
-						$el.css('right', 1);
+						$el.css("right", 1);
 					} else {
-						$el.css('left', offsetLeft);
+						$el.css("left", offsetLeft);
 					}
-
 				} else {
-
-					if (room > offset.top + sourceHeight + height + 5 &&
-						(offset.top + sourceHeight < room * 2 / 3 || offset.top + sourceHeight + 200 < room)) {
-						$el.css('top', offset.top + sourceHeight);
+					if (
+						room > offset.top + sourceHeight + height + 5 &&
+						(offset.top + sourceHeight < (room * 2) / 3 ||
+							offset.top + sourceHeight + 200 < room)
+					) {
+						$el.css("top", offset.top + sourceHeight);
 					} else if (height + 5 <= offset.top) {
-						$el.css('bottom', Math.max(room - offset.top, 0));
+						$el.css("bottom", Math.max(room - offset.top, 0));
 					} else if (height + 10 < room) {
-						$el.css('bottom', 5);
+						$el.css("bottom", 5);
 					} else {
-						$el.css('top', 0);
+						$el.css("top", 0);
 					}
 
 					room = $(window).width() - offset.left;
 					if (room < width + 10) {
-						$el.css('right', 10);
+						$el.css("right", 10);
 					} else {
-						$el.css('left', offset.left);
+						$el.css("left", offset.left);
 					}
-
 				}
 
 				$el.detach();
@@ -2466,8 +2971,17 @@ function toId() {
 			}
 		},
 		initialize: function (data) {
-			if (!this.type) this.type = 'semimodal';
-			this.$el.html('<form><p style="white-space:pre-wrap;word-wrap:break-word">' + (data.htmlMessage || BattleLog.parseMessage(data.message)) + '</p><p class="buttonbar">' + (data.buttons || '<button type="button" name="close" class="autofocus"><strong>OK</strong></button>') + '</p></form>').css('max-width', data.maxWidth || 480);
+			if (!this.type) this.type = "semimodal";
+			this.$el
+				.html(
+					'<form><p style="white-space:pre-wrap;word-wrap:break-word">' +
+						(data.htmlMessage || BattleLog.parseMessage(data.message)) +
+						'</p><p class="buttonbar">' +
+						(data.buttons ||
+							'<button type="button" name="close" class="autofocus"><strong>OK</strong></button>') +
+						"</p></form>"
+				)
+				.css("max-width", data.maxWidth || 480);
 		},
 
 		dispatchClickButton: function (e) {
@@ -2488,12 +3002,13 @@ function toId() {
 			var dataArray = $(e.currentTarget).serializeArray();
 			var data = {};
 			for (var i = 0, len = dataArray.length; i < len; i++) {
-				var name = dataArray[i].name, value = dataArray[i].value;
+				var name = dataArray[i].name,
+					value = dataArray[i].value;
 				if (data[name]) {
 					if (!data[name].push) data[name] = [data[name]];
-					data[name].push(value || '');
+					data[name].push(value || "");
 				} else {
-					data[name] = (value || '');
+					data[name] = value || "";
 				}
 			}
 			this.submit(data);
@@ -2505,7 +3020,7 @@ function toId() {
 		remove: function () {
 			var $parent = this.$el.parent();
 			Backbone.View.prototype.remove.apply(this, arguments);
-			if ($parent.hasClass('ps-overlay')) $parent.remove();
+			if ($parent.hasClass("ps-overlay")) $parent.remove();
 		},
 
 		close: function () {
@@ -2513,269 +3028,358 @@ function toId() {
 		},
 
 		register: function () {
-			var registered = app.user.get('registered');
+			var registered = app.user.get("registered");
 			app.closePopup();
-			if (!registered || registered.userid !== app.user.get('userid')) {
+			if (!registered || registered.userid !== app.user.get("userid")) {
 				app.addPopup(RegisterPopup);
 			} else {
 				app.addPopupMessage("You are already registered!");
 			}
 		},
-	});
+	}));
 
-	var PromptPopup = this.PromptPopup = Popup.extend({
+	var PromptPopup = (this.PromptPopup = Popup.extend({
 		initialize: function (data) {
-			if (!data || !data.message || typeof data.callback !== "function") return;
+			if (!data || !data.message || typeof data.callback !== "function")
+				return;
 			this.callback = data.callback;
 
-			var buf = '<form>';
+			var buf = "<form>";
 			buf += '<p><label class="label">' + data.message;
-			buf += '<input class="textbox autofocus" type="text" name="data" value="' + BattleLog.escapeHTML(data.value || '') + '" /></label></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>' + data.button + '</strong></button> <button type="button" name="close">Cancel</button></p>';
-			buf += '</form>';
+			buf +=
+				'<input class="textbox autofocus" type="text" name="data" value="' +
+				BattleLog.escapeHTML(data.value || "") +
+				'" /></label></p>';
+			buf +=
+				'<p class="buttonbar"><button type="submit"><strong>' +
+				data.button +
+				'</strong></button> <button type="button" name="close">Cancel</button></p>';
+			buf += "</form>";
 
 			this.$el.html(buf);
 		},
 		submit: function (data) {
 			this.close();
 			this.callback(data.data);
-		}
-	});
+		},
+	}));
 
 	Config.groups = Config.groups || {
-		'~': {
+		"~": {
 			name: "Administrator (~)",
-			type: 'leadership',
-			order: 10001
+			type: "leadership",
+			order: 10001,
 		},
-		'#': {
+		"#": {
 			name: "Room Owner (#)",
-			type: 'leadership',
-			order: 10002
+			type: "leadership",
+			order: 10002,
 		},
-		'&': {
+		"&": {
 			name: "Administrator (&amp;)",
-			type: 'leadership',
-			order: 10003
+			type: "leadership",
+			order: 10003,
 		},
-		'\u2605': {
+		"\u2605": {
 			name: "Host (\u2605)",
-			type: 'staff',
-			order: 10004
+			type: "staff",
+			order: 10004,
 		},
-		'@': {
+		"@": {
 			name: "Moderator (@)",
-			type: 'staff',
-			order: 10005
+			type: "staff",
+			order: 10005,
 		},
-		'%': {
+		"%": {
 			name: "Driver (%)",
-			type: 'staff',
-			order: 10006
+			type: "staff",
+			order: 10006,
 		},
-		'\u00a7': {
+		"\u00a7": {
 			name: "Section Leader (\u00a7)",
-			type: 'staff',
-			order: 10007
+			type: "staff",
+			order: 10007,
 		},
-		'*': {
+		"*": {
 			name: "Bot (*)",
-			type: 'normal',
-			order: 10008
+			type: "normal",
+			order: 10008,
 		},
-		'\u2606': {
+		"\u2606": {
 			name: "Player (\u2606)",
-			type: 'normal',
-			order: 10009
+			type: "normal",
+			order: 10009,
 		},
-		'+': {
+		"+": {
 			name: "Voice (+)",
-			type: 'normal',
-			order: 10010
+			type: "normal",
+			order: 10010,
 		},
-		' ': {
-			type: 'normal',
-			order: 10011
+		" ": {
+			type: "normal",
+			order: 10011,
 		},
-		'!': {
+		"!": {
 			name: "<span style='color:#777777'>Muted (!)</span>",
-			type: 'punishment',
-			order: 10012
+			type: "punishment",
+			order: 10012,
 		},
-		'✖': {
+		"✖": {
 			name: "<span style='color:#777777'>Namelocked (✖)</span>",
-			type: 'punishment',
-			order: 10013
+			type: "punishment",
+			order: 10013,
 		},
-		'\u203d': {
+		"\u203d": {
 			name: "<span style='color:#777777'>Locked (\u203d)</span>",
-			type: 'punishment',
-			order: 10014
-		}
+			type: "punishment",
+			order: 10014,
+		},
 	};
 
-	var UserPopup = this.UserPopup = Popup.extend({
-		initialize: function (data) {
-			data.userid = toID(data.name);
-			var name = data.name;
-			this.data = data = _.extend(data, UserPopup.dataCache[data.userid]);
-			data.name = name;
-			app.on('response:userdetails', this.update, this);
-			app.send('/cmd userdetails ' + data.userid);
-			this.update();
-		},
-		events: {
-			'click .ilink': 'clickLink',
-			'click .trainersprite.yours': 'avatars'
-		},
-		update: function (data) {
-			if (data && data.userid === this.data.userid) {
-				data = _.extend(this.data, data);
-				// Don't cache the roomGroup or status
-				UserPopup.dataCache[data.userid] = _.clone(data);
-				delete UserPopup.dataCache[data.userid].roomGroup;
-				delete UserPopup.dataCache[data.userid].status;
-			} else {
-				data = this.data;
-			}
-			var userid = data.userid;
-			var name = data.name;
-			var avatar = data.avatar || '';
-			var groupName = ((Config.groups[data.roomGroup] || {}).name || '');
-			var globalGroup = (Config.groups[data.group || Config.defaultGroup || ' '] || null);
-			var globalGroupName = '';
-			if (globalGroup && globalGroup.name && toID(globalGroup.name) !== toID(data.customgroup)) {
-				if (globalGroup.type === 'punishment') {
-					groupName = globalGroup.name;
-				} else if (!groupName || groupName === globalGroup.name) {
-					groupName = "Global " + globalGroup.name;
+	var UserPopup = (this.UserPopup = Popup.extend(
+		{
+			initialize: function (data) {
+				data.userid = toID(data.name);
+				var name = data.name;
+				this.data = data = _.extend(data, UserPopup.dataCache[data.userid]);
+				data.name = name;
+				app.on("response:userdetails", this.update, this);
+				app.send("/cmd userdetails " + data.userid);
+				this.update();
+			},
+			events: {
+				"click .ilink": "clickLink",
+				"click .trainersprite.yours": "avatars",
+			},
+			update: function (data) {
+				if (data && data.userid === this.data.userid) {
+					data = _.extend(this.data, data);
+					// Don't cache the roomGroup or status
+					UserPopup.dataCache[data.userid] = _.clone(data);
+					delete UserPopup.dataCache[data.userid].roomGroup;
+					delete UserPopup.dataCache[data.userid].status;
 				} else {
-					globalGroupName = "Global " + globalGroup.name;
+					data = this.data;
 				}
-			}
-			var ownUserid = app.user.get('userid');
-
-			var buf = '<div class="userdetails">';
-			if (avatar) buf += '<img class="trainersprite' + (userid === ownUserid ? ' yours' : '') + '" src="' + Dex.resolveAvatar(avatar) + '" />';
-			buf += '<strong><a href="//' + Config.routes.users + '/' + userid + '" target="_blank">' + BattleLog.escapeHTML(name) + '</a></strong><br />';
-			var offline = data.rooms === false;
-			if (data.status || offline) {
-				var status = offline ? '(Offline)' : data.status.startsWith('!') ? data.status.slice(1) : data.status;
-				buf += '<span class="userstatus' + (offline ? ' offline' : '') + '">' + BattleLog.escapeHTML(status) + '<br /></span>';
-			}
-			if (groupName) {
-				buf += '<small class="usergroup roomgroup">' + groupName + '</small>';
-				if (globalGroupName) buf += '<br />';
-			}
-			if (globalGroupName) {
-				buf += '<small class="usergroup globalgroup">' + globalGroupName + '</small>';
-			}
-			if (data.customgroup && toID(data.customgroup) !== toID(globalGroupName || groupName)) {
-				if (groupName || globalGroupName) buf += '<br />';
-				buf += '<small class="usergroup globalgroup">' + BattleLog.escapeHTML(data.customgroup) + '</small>';
-			}
-			if (data.rooms) {
-				var battlebuf = '';
-				var chatbuf = '';
-				var privatebuf = '';
-				for (var i in data.rooms) {
-					if (i === 'global') continue;
-					var roomrank = '';
-					if (!/[A-Za-z0-9]/.test(i.charAt(0))) {
-						roomrank = '<small style="color: #888; font-size: 100%">' + i.charAt(0) + '</small>';
-					}
-					var roomid = toRoomid(i);
-					if (roomid.substr(0, 7) === 'battle-') {
-						var p1 = data.rooms[i].p1.substr(1);
-						var p2 = data.rooms[i].p2.substr(1);
-						var ownBattle = (ownUserid === toUserid(p1) || ownUserid === toUserid(p2));
-						var room = '<span title="' + (BattleLog.escapeHTML(p1) || '?') + ' v. ' + (BattleLog.escapeHTML(p2) || '?') + '">' + '<a href="' + app.root + roomid + '" class="ilink' + ((ownBattle || app.rooms[i]) ? ' yours' : '') + '">' + roomrank + roomid.substr(7) + '</a></span>';
-						if (data.rooms[i].isPrivate) {
-							if (!privatebuf) privatebuf = '<br /><em>Private rooms:</em> ';
-							else privatebuf += ', ';
-							privatebuf += room;
-						} else {
-							if (!battlebuf) battlebuf = '<br /><em>Battles:</em> ';
-							else battlebuf += ', ';
-							battlebuf += room;
-						}
+				var userid = data.userid;
+				var name = data.name;
+				var avatar = data.avatar || "";
+				var groupName = (Config.groups[data.roomGroup] || {}).name || "";
+				var globalGroup =
+					Config.groups[data.group || Config.defaultGroup || " "] || null;
+				var globalGroupName = "";
+				if (
+					globalGroup &&
+					globalGroup.name &&
+					toID(globalGroup.name) !== toID(data.customgroup)
+				) {
+					if (globalGroup.type === "punishment") {
+						groupName = globalGroup.name;
+					} else if (!groupName || groupName === globalGroup.name) {
+						groupName = "Global " + globalGroup.name;
 					} else {
-						var room = '<a href="' + app.root + roomid + '" class="ilink' + (app.rooms[i] ? ' yours' : '') + '">' + roomrank + roomid + '</a>';
-						if (data.rooms[i].isPrivate) {
-							if (!privatebuf) privatebuf = '<br /><em>Private rooms:</em> ';
-							else privatebuf += ', ';
-							privatebuf += room;
-						} else {
-							if (!chatbuf) chatbuf = '<br /><em>Chatrooms:</em> ';
-							else chatbuf += ', ';
-							chatbuf += room;
-						}
+						globalGroupName = "Global " + globalGroup.name;
 					}
 				}
-				buf += '<small class="rooms">' + battlebuf + chatbuf + privatebuf + '</small>';
-			}
-			buf += '</div>';
+				var ownUserid = app.user.get("userid");
 
-			buf += '<p class="buttonbar">';
-			if (userid === app.user.get('userid') || !app.user.get('named')) {
-				buf += '<button disabled>Challenge</button>';
-				if (userid === app.user.get('userid')) {
-					buf += ' <button name="pm">Chat self</button>';
-					buf += '</p><hr /><p class="buttonbar" style="text-align: right">';
-					buf += '<button name="login"><i class="fa fa-pencil"></i> Change name</button> <button name="logout"><i class="fa fa-power-off"></i> Log out</button>';
-				} else {
-					// Guests can't PM themselves
-					buf += ' <button disabled>Chat self</button>';
+				var buf = '<div class="userdetails">';
+				if (avatar)
+					buf +=
+						'<img class="trainersprite' +
+						(userid === ownUserid ? " yours" : "") +
+						'" src="' +
+						Dex.resolveAvatar(avatar) +
+						'" />';
+				buf +=
+					'<strong><a href="//' +
+					Config.routes.users +
+					"/" +
+					userid +
+					'" target="_blank">' +
+					BattleLog.escapeHTML(name) +
+					"</a></strong><br />";
+				var offline = data.rooms === false;
+				if (data.status || offline) {
+					var status = offline
+						? "(Offline)"
+						: data.status.startsWith("!")
+						? data.status.slice(1)
+						: data.status;
+					buf +=
+						'<span class="userstatus' +
+						(offline ? " offline" : "") +
+						'">' +
+						BattleLog.escapeHTML(status) +
+						"<br /></span>";
 				}
-			} else {
-				buf += '<button name="challenge">Challenge</button> <button name="pm">Chat</button> <button name="userOptions">\u2026</button>';
-			}
-			buf += '</p>';
+				if (groupName) {
+					buf +=
+						'<small class="usergroup roomgroup">' +
+						groupName +
+						"</small>";
+					if (globalGroupName) buf += "<br />";
+				}
+				if (globalGroupName) {
+					buf +=
+						'<small class="usergroup globalgroup">' +
+						globalGroupName +
+						"</small>";
+				}
+				if (
+					data.customgroup &&
+					toID(data.customgroup) !== toID(globalGroupName || groupName)
+				) {
+					if (groupName || globalGroupName) buf += "<br />";
+					buf +=
+						'<small class="usergroup globalgroup">' +
+						BattleLog.escapeHTML(data.customgroup) +
+						"</small>";
+				}
+				if (data.rooms) {
+					var battlebuf = "";
+					var chatbuf = "";
+					var privatebuf = "";
+					for (var i in data.rooms) {
+						if (i === "global") continue;
+						var roomrank = "";
+						if (!/[A-Za-z0-9]/.test(i.charAt(0))) {
+							roomrank =
+								'<small style="color: #888; font-size: 100%">' +
+								i.charAt(0) +
+								"</small>";
+						}
+						var roomid = toRoomid(i);
+						if (roomid.substr(0, 7) === "battle-") {
+							var p1 = data.rooms[i].p1.substr(1);
+							var p2 = data.rooms[i].p2.substr(1);
+							var ownBattle =
+								ownUserid === toUserid(p1) ||
+								ownUserid === toUserid(p2);
+							var room =
+								'<span title="' +
+								(BattleLog.escapeHTML(p1) || "?") +
+								" v. " +
+								(BattleLog.escapeHTML(p2) || "?") +
+								'">' +
+								'<a href="' +
+								app.root +
+								roomid +
+								'" class="ilink' +
+								(ownBattle || app.rooms[i] ? " yours" : "") +
+								'">' +
+								roomrank +
+								roomid.substr(7) +
+								"</a></span>";
+							if (data.rooms[i].isPrivate) {
+								if (!privatebuf)
+									privatebuf = "<br /><em>Private rooms:</em> ";
+								else privatebuf += ", ";
+								privatebuf += room;
+							} else {
+								if (!battlebuf) battlebuf = "<br /><em>Battles:</em> ";
+								else battlebuf += ", ";
+								battlebuf += room;
+							}
+						} else {
+							var room =
+								'<a href="' +
+								app.root +
+								roomid +
+								'" class="ilink' +
+								(app.rooms[i] ? " yours" : "") +
+								'">' +
+								roomrank +
+								roomid +
+								"</a>";
+							if (data.rooms[i].isPrivate) {
+								if (!privatebuf)
+									privatebuf = "<br /><em>Private rooms:</em> ";
+								else privatebuf += ", ";
+								privatebuf += room;
+							} else {
+								if (!chatbuf) chatbuf = "<br /><em>Chatrooms:</em> ";
+								else chatbuf += ", ";
+								chatbuf += room;
+							}
+						}
+					}
+					buf +=
+						'<small class="rooms">' +
+						battlebuf +
+						chatbuf +
+						privatebuf +
+						"</small>";
+				}
+				buf += "</div>";
 
-			this.$el.html(buf);
+				buf += '<p class="buttonbar">';
+				if (userid === app.user.get("userid") || !app.user.get("named")) {
+					buf += "<button disabled>Challenge</button>";
+					if (userid === app.user.get("userid")) {
+						buf += ' <button name="pm">Chat self</button>';
+						buf +=
+							'</p><hr /><p class="buttonbar" style="text-align: right">';
+						buf +=
+							'<button name="login"><i class="fa fa-pencil"></i> Change name</button> <button name="logout"><i class="fa fa-power-off"></i> Log out</button>';
+					} else {
+						// Guests can't PM themselves
+						buf += " <button disabled>Chat self</button>";
+					}
+				} else {
+					buf +=
+						'<button name="challenge">Challenge</button> <button name="pm">Chat</button> <button name="userOptions">\u2026</button>';
+				}
+				buf += "</p>";
+
+				this.$el.html(buf);
+			},
+			clickLink: function (e) {
+				if (e.cmdKey || e.metaKey || e.ctrlKey) return;
+				e.preventDefault();
+				e.stopPropagation();
+				this.close();
+				var roomid = $(e.currentTarget)
+					.attr("href")
+					.substr(app.root.length);
+				app.tryJoinRoom(roomid);
+			},
+			avatars: function () {
+				app.addPopup(AvatarsPopup);
+			},
+			challenge: function () {
+				app.rooms[""].requestNotifications();
+				this.close();
+				app.focusRoom("");
+				app.rooms[""].challenge(this.data.name);
+			},
+			pm: function () {
+				app.rooms[""].requestNotifications();
+				this.close();
+				app.focusRoom("");
+				app.rooms[""].focusPM(this.data.name);
+			},
+			login: function () {
+				app.addPopup(LoginPopup);
+			},
+			logout: function () {
+				app.user.logout();
+				this.close();
+			},
+			userOptions: function () {
+				app.addPopup(UserOptionsPopup, {
+					name: this.data.name,
+					userid: this.data.userid,
+					friended: this.data.friended,
+				});
+			},
 		},
-		clickLink: function (e) {
-			if (e.cmdKey || e.metaKey || e.ctrlKey) return;
-			e.preventDefault();
-			e.stopPropagation();
-			this.close();
-			var roomid = $(e.currentTarget).attr('href').substr(app.root.length);
-			app.tryJoinRoom(roomid);
-		},
-		avatars: function () {
-			app.addPopup(AvatarsPopup);
-		},
-		challenge: function () {
-			app.rooms[''].requestNotifications();
-			this.close();
-			app.focusRoom('');
-			app.rooms[''].challenge(this.data.name);
-		},
-		pm: function () {
-			app.rooms[''].requestNotifications();
-			this.close();
-			app.focusRoom('');
-			app.rooms[''].focusPM(this.data.name);
-		},
-		login: function () {
-			app.addPopup(LoginPopup);
-		},
-		logout: function () {
-			app.user.logout();
-			this.close();
-		},
-		userOptions: function () {
-			app.addPopup(UserOptionsPopup, {
-				name: this.data.name,
-				userid: this.data.userid,
-				friended: this.data.friended,
-			});
+		{
+			dataCache: {},
 		}
-	}, {
-		dataCache: {}
-	});
+	));
 
-	var UserOptionsPopup = this.UserOptions = Popup.extend({
+	var UserOptionsPopup = (this.UserOptions = Popup.extend({
 		initialize: function (data) {
 			this.name = data.name;
 			this.userid = data.userid;
@@ -2783,30 +3387,33 @@ function toId() {
 			this.update();
 		},
 		update: function () {
-			var ignored = app.ignore[this.userid] ? 'Unignore' : 'Ignore';
-			var friended = this.data.friended ? 'Remove friend' : 'Add friend';
+			var ignored = app.ignore[this.userid] ? "Unignore" : "Ignore";
+			var friended = this.data.friended ? "Remove friend" : "Add friend";
 			this.$el.html(
-				'<p><button name="toggleIgnoreUser">' + ignored + '</button></p>' +
-				'<p><button name="report">Report</button></p>' +
-				'<p><button name="toggleFriend">' + friended +
-				'</button></p>'
+				'<p><button name="toggleIgnoreUser">' +
+					ignored +
+					"</button></p>" +
+					'<p><button name="report">Report</button></p>' +
+					'<p><button name="toggleFriend">' +
+					friended +
+					"</button></p>"
 			);
 		},
 		toggleFriend: function () {
-			var $button = this.$el.find('[name=toggleFriend]');
+			var $button = this.$el.find("[name=toggleFriend]");
 			if (this.data.friended) {
-				app.send('/unfriend ' + this.userid);
-				$button.text('Friend removed.');
+				app.send("/unfriend " + this.userid);
+				$button.text("Friend removed.");
 			} else {
-				app.send('/friend add ' + this.userid);
-				$button.text('Friend request sent!');
+				app.send("/friend add " + this.userid);
+				$button.text("Friend request sent!");
 			}
 			// we intentionally disable since we don't want them to spam it
 			// you at least have to close and reopen the popup to get it back
-			$button.addClass('button disabled');
+			$button.addClass("button disabled");
 		},
 		report: function () {
-			app.joinRoom('view-help-request-report-user-' + this.userid);
+			app.joinRoom("view-help-request-report-user-" + this.userid);
 		},
 		toggleIgnoreUser: function () {
 			var buf = "User '" + this.name + "'";
@@ -2818,11 +3425,14 @@ function toId() {
 				buf += " ignored. (Moderator messages will not be ignored.)";
 			}
 			app.saveIgnore();
-			var $pm = $('.pm-window-' + this.userid);
-			if ($pm.length && $pm.css('display') !== 'none') {
-				$pm.find('.inner').append('<div class="chat">' + BattleLog.escapeHTML(buf) + '</div>');
+			var $pm = $(".pm-window-" + this.userid);
+			if ($pm.length && $pm.css("display") !== "none") {
+				$pm.find(".inner").append(
+					'<div class="chat">' + BattleLog.escapeHTML(buf) + "</div>"
+				);
 			} else {
-				var room = (app.curRoom && app.curRoom.add ? app.curRoom : app.curSideRoom);
+				var room =
+					app.curRoom && app.curRoom.add ? app.curRoom : app.curSideRoom;
 				if (!room || !room.add) {
 					app.addPopupMessage(buf);
 					return this.update();
@@ -2830,77 +3440,105 @@ function toId() {
 				room.add(buf);
 			}
 			app.dismissPopups();
-		}
-	});
+		},
+	}));
 
-	var ReconnectPopup = this.ReconnectPopup = Popup.extend({
-		type: 'modal',
+	var ReconnectPopup = (this.ReconnectPopup = Popup.extend({
+		type: "modal",
 		initialize: function (data) {
 			app.reconnectPending = false;
-			var buf = '<form>';
+			var buf = "<form>";
 
 			if (data.cantconnect) {
 				buf += '<p class="error">Couldn\'t connect to server!</p>';
-				if (window.wiiu && document.location.protocol === 'https:') {
-					buf += '<p class="error">The Wii U does not support secure connections.</p>';
-					buf += '<p class="buttonbar"><button name="tryhttp" autofocus><strong>Connect insecurely</button> <button name="close">Work offline</button></p>';
-				} else if (document.location.protocol === 'https:') {
-					buf += '<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="tryhttp">Retry with HTTP</button> <button name="close">Work offline</button></p>';
+				if (window.wiiu && document.location.protocol === "https:") {
+					buf +=
+						'<p class="error">The Wii U does not support secure connections.</p>';
+					buf +=
+						'<p class="buttonbar"><button name="tryhttp" autofocus><strong>Connect insecurely</button> <button name="close">Work offline</button></p>';
+				} else if (document.location.protocol === "https:") {
+					buf +=
+						'<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="tryhttp">Retry with HTTP</button> <button name="close">Work offline</button></p>';
 				} else {
-					buf += '<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="close">Work offline</button></p>';
+					buf +=
+						'<p class="buttonbar"><button type="submit"><strong>Retry</strong></button> <button name="close">Work offline</button></p>';
 				}
 			} else if (data.message && data.message !== true) {
-				buf += '<p>' + data.message + '</p>';
-				buf += '<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
+				buf += "<p>" + data.message + "</p>";
+				buf +=
+					'<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
 			} else {
-				buf += '<p>You have been disconnected &ndash; possibly because the server was restarted.</p>';
-				buf += '<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
+				buf +=
+					"<p>You have been disconnected &ndash; possibly because the server was restarted.</p>";
+				buf +=
+					'<p class="buttonbar"><button type="submit" class="autofocus"><strong>Reconnect</strong></button> <button type="button" name="close">Work offline</button></p>';
 			}
 
-			buf += '</form>';
+			buf += "</form>";
 			this.$el.html(buf);
 		},
 		tryhttp: function () {
-			document.location.replace('http://' +
-				document.location.host + document.location.pathname + '?insecure');
+			document.location.replace(
+				"http://" +
+					document.location.host +
+					document.location.pathname +
+					"?insecure"
+			);
 		},
 		submit: function (data) {
 			document.location.reload();
-		}
-	});
+		},
+	}));
 
 	this.ProxyPopup = Popup.extend({
-		type: 'modal',
+		type: "modal",
 		initialize: function (data) {
 			this.callback = data.callback;
 
-			var buf = '<form>';
-			buf += '<p>Because of <a href="https://en.wikipedia.org/wiki/Same-origin_policy" target="_blank">your browser\'s security restrictions</a> for <code>testclient.html</code>, we need to do this manually:</p>';
-			buf += '<iframe id="overlay_iframe" src="' + data.uri + '" style="width: 100%; height: 50px;" class="textbox"></iframe>';
-			buf += '<p>Please copy <strong>all the text</strong> from the box above and paste it in the box below.</p>';
-			buf += '<p>(You should probably <a href="https://github.com/smogon/pokemon-showdown-client#test-keys" target="_blank">set up</a> <code>config/testclient-key.js</code> so you don\'t have to do this every time.)</p>';
-			buf += '<p><label class="label" style="float: left;">Data from the box above:</label> <input style="width: 100%;" class="textbox autofocus" type="text" name="result" /></p>';
-			buf += '<p class="buttonbar"><button type="submit"><strong>Submit</strong></button> <button type="button" name="close">Cancel</button></p>';
-			buf += '</form>';
-			this.$el.html(buf).css('min-width', 500);
+			var buf = "<form>";
+			buf +=
+				'<p>Because of <a href="https://en.wikipedia.org/wiki/Same-origin_policy" target="_blank">your browser\'s security restrictions</a> for <code>testclient.html</code>, we need to do this manually:</p>';
+			buf +=
+				'<iframe id="overlay_iframe" src="' +
+				data.uri +
+				'" style="width: 100%; height: 50px;" class="textbox"></iframe>';
+			buf +=
+				"<p>Please copy <strong>all the text</strong> from the box above and paste it in the box below.</p>";
+			buf +=
+				'<p>(You should probably <a href="https://github.com/smogon/pokemon-showdown-client#test-keys" target="_blank">set up</a> <code>config/testclient-key.js</code> so you don\'t have to do this every time.)</p>';
+			buf +=
+				'<p><label class="label" style="float: left;">Data from the box above:</label> <input style="width: 100%;" class="textbox autofocus" type="text" name="result" /></p>';
+			buf +=
+				'<p class="buttonbar"><button type="submit"><strong>Submit</strong></button> <button type="button" name="close">Cancel</button></p>';
+			buf += "</form>";
+			this.$el.html(buf).css("min-width", 500);
 		},
 		submit: function (data) {
 			this.close();
 			this.callback(data.result);
-		}
+		},
 	});
 
-	var ReplayUploadedPopup = this.ReplayUploadedPopup = Popup.extend({
-		type: 'semimodal',
+	var ReplayUploadedPopup = (this.ReplayUploadedPopup = Popup.extend({
+		type: "semimodal",
 		events: {
-			'click a': 'clickClose'
+			"click a": "clickClose",
 		},
 		initialize: function (data) {
-			var buf = '';
-			buf = '<p>Your replay has been uploaded! It\'s available at:</p>';
-			buf += '<p> <a class="replay-link" href="https://' + Config.routes.replays + '/' + data.id + '" target="_blank" class="no-panel-intercept">https://' + Config.routes.replays + '/' + data.id + '</a> <button name="copyReplayLink">Copy</button></p>';
+			var buf = "";
+			buf = "<p>Your replay has been uploaded! It's available at:</p>";
+			buf +=
+				'<p> <a class="replay-link" href="https://' +
+				Config.routes.replays +
+				"/" +
+				data.id +
+				'" target="_blank" class="no-panel-intercept">https://' +
+				Config.routes.replays +
+				"/" +
+				data.id +
+				'</a> <button name="copyReplayLink">Copy</button></p>';
 			buf += '<p><button class="autofocus" name="close">Close</button><p>';
-			this.$el.html(buf).css('max-width', 620);
+			this.$el.html(buf).css("max-width", 620);
 		},
 		clickClose: function () {
 			this.close();
@@ -2914,58 +3552,65 @@ function toId() {
 			// This is a hack. You can only "select" an input field. The trick is to create a short lived input element and destroy it after a copy.
 			dummyReplayLink.id = "dummyReplayLink";
 			dummyReplayLink.value = copyText.href;
-			dummyReplayLink.style.position = 'absolute';
+			dummyReplayLink.style.position = "absolute";
 			copyText.appendChild(dummyReplayLink);
 			dummyReplayLink.select();
 			document.execCommand("copy");
 			copyText.removeChild(dummyReplayLink);
-		}
-	});
+		},
+	}));
 
-	var RulesPopup = this.RulesPopup = Popup.extend({
-		type: 'modal',
+	var RulesPopup = (this.RulesPopup = Popup.extend({
+		type: "modal",
 		initialize: function (data) {
-			var warning = ('warning' in data);
-			var buf = '';
+			var warning = "warning" in data;
+			var buf = "";
 			if (warning) {
-				buf += '<p><strong style="color:red">' + (BattleLog.escapeHTML(data.warning) || 'You have been warned for breaking the rules.') + '</strong></p>';
+				buf +=
+					'<p><strong style="color:red">' +
+					(BattleLog.escapeHTML(data.warning) ||
+						"You have been warned for breaking the rules.") +
+					"</strong></p>";
 			}
-			buf += '<h2>Pok&eacute;mon Showdown Rules</h2>';
-			buf += '<p><b>Global</b></p>' +
-				'<p><b>1.</b> Be nice to people. Respect people. Don\'t be rude or mean to people.</p>' +
-				'<p><b>2.</b> Follow US laws (PS is based in the US). No porn (minors use PS), don\'t distribute pirated material, and don\'t slander others.</p>' +
-				'<p><b>3.</b>&nbsp;No sex. Don\'t discuss anything sexually explicit, not even in private messages, not even if you\'re both adults.</p>' +
-				'<p><b>4.</b>&nbsp;No cheating. Don\'t exploit bugs to gain an unfair advantage. Don\'t game the system (by intentionally losing against yourself or a friend in a ladder match, by timerstalling, etc). Don\'t impersonate staff if you\'re not.</p>' +
-				'<p><b>5.</b> Moderators have discretion to punish any behaviour they deem inappropriate, whether or not it\'s on this list. If you disagree with a moderator ruling, appeal to an administrator (a user with &amp; next to their name) or <a href=\'https://pokemonshowdown.com/appeal\'>Discipline Appeals</a>.</p>' +
-				'<p>(Note: The First Amendment does not apply to PS, since PS is not a government organization.)</p>' +
-				'<p><b>Chat</b></p>' +
-				'<p><b>1.</b> Do not spam, flame, or troll. This includes advertising, raiding, asking questions with one-word answers in the lobby, and flooding the chat such as by copy/pasting logs in the lobby.</p>' +
-				'<p><b>2.</b> Don\'t call unnecessary attention to yourself. Don\'t be obnoxious. ALL CAPS and <i>formatting</i> are acceptable to emphasize things, but should be used sparingly, not all the time.</p>' +
-				'<p><b>3.</b> No minimodding: don\'t mod if it\'s not your job. Don\'t tell people they\'ll be muted, don\'t ask for people to be muted, and don\'t talk about whether or not people should be muted (\'inb4 mute\', etc). This applies to bans and other punishments, too.</p>' +
-				'<p><b>4.</b> We reserve the right to tell you to stop discussing moderator decisions if you become unreasonable or belligerent</p>' +
-				'<p><b>5.</b> English only, unless specified otherwise.</p>' +
-				'<p>(Note: You can opt out of chat rules in private chat rooms and battle rooms, but only if all ROs or players agree to it.)</p>';
+			buf += "<h2>Pok&eacute;mon Showdown Rules</h2>";
+			buf +=
+				"<p><b>Global</b></p>" +
+				"<p><b>1.</b> Be nice to people. Respect people. Don't be rude or mean to people.</p>" +
+				"<p><b>2.</b> Follow US laws (PS is based in the US). No porn (minors use PS), don't distribute pirated material, and don't slander others.</p>" +
+				"<p><b>3.</b>&nbsp;No sex. Don't discuss anything sexually explicit, not even in private messages, not even if you're both adults.</p>" +
+				"<p><b>4.</b>&nbsp;No cheating. Don't exploit bugs to gain an unfair advantage. Don't game the system (by intentionally losing against yourself or a friend in a ladder match, by timerstalling, etc). Don't impersonate staff if you're not.</p>" +
+				"<p><b>5.</b> Moderators have discretion to punish any behaviour they deem inappropriate, whether or not it's on this list. If you disagree with a moderator ruling, appeal to an administrator (a user with &amp; next to their name) or <a href='https://pokemonshowdown.com/appeal'>Discipline Appeals</a>.</p>" +
+				"<p>(Note: The First Amendment does not apply to PS, since PS is not a government organization.)</p>" +
+				"<p><b>Chat</b></p>" +
+				"<p><b>1.</b> Do not spam, flame, or troll. This includes advertising, raiding, asking questions with one-word answers in the lobby, and flooding the chat such as by copy/pasting logs in the lobby.</p>" +
+				"<p><b>2.</b> Don't call unnecessary attention to yourself. Don't be obnoxious. ALL CAPS and <i>formatting</i> are acceptable to emphasize things, but should be used sparingly, not all the time.</p>" +
+				"<p><b>3.</b> No minimodding: don't mod if it's not your job. Don't tell people they'll be muted, don't ask for people to be muted, and don't talk about whether or not people should be muted ('inb4 mute', etc). This applies to bans and other punishments, too.</p>" +
+				"<p><b>4.</b> We reserve the right to tell you to stop discussing moderator decisions if you become unreasonable or belligerent</p>" +
+				"<p><b>5.</b> English only, unless specified otherwise.</p>" +
+				"<p>(Note: You can opt out of chat rules in private chat rooms and battle rooms, but only if all ROs or players agree to it.)</p>";
 			if (!warning) {
-				buf += '<p><b>Usernames</b></p>' +
-					'<p>Your username can be chosen and changed at any time. Keep in mind:</p>' +
-					'<p><b>1.</b> Usernames may not impersonate a recognized user (a user with %, @, #, or &amp; next to their name) or a famous person/organization that uses PS or is associated with Pokémon.</p>' +
-					'<p><b>2.</b> Usernames may not be derogatory or insulting in nature, to an individual or group (insulting yourself is okay as long as it\'s not too serious).</p>' +
-					'<p><b>3.</b> Usernames may not directly reference sexual activity, or be excessively disgusting.</p>' +
+				buf +=
+					"<p><b>Usernames</b></p>" +
+					"<p>Your username can be chosen and changed at any time. Keep in mind:</p>" +
+					"<p><b>1.</b> Usernames may not impersonate a recognized user (a user with %, @, #, or &amp; next to their name) or a famous person/organization that uses PS or is associated with Pokémon.</p>" +
+					"<p><b>2.</b> Usernames may not be derogatory or insulting in nature, to an individual or group (insulting yourself is okay as long as it's not too serious).</p>" +
+					"<p><b>3.</b> Usernames may not directly reference sexual activity, or be excessively disgusting.</p>" +
 					'<p>This policy is less restrictive than that of many places, so you might see some "borderline" nicknames that might not be accepted elsewhere. You might consider it unfair that they are allowed to keep their nickname. The fact remains that their nickname follows the above rules, and if you were asked to choose a new name, yours does not.</p>';
 			}
 			if (warning) {
-				buf += '<p class="buttonbar"><button name="close" disabled>Close</button><small class="overlay-warn"> You will be able to close this in 5 seconds</small></p>';
+				buf +=
+					'<p class="buttonbar"><button name="close" disabled>Close</button><small class="overlay-warn"> You will be able to close this in 5 seconds</small></p>';
 				setTimeout(_.bind(this.rulesTimeout, this), 5000);
 			} else {
-				this.type = 'semimodal';
-				buf += '<p class="buttonbar"><button name="close" class="autofocus">Close</button></p>';
+				this.type = "semimodal";
+				buf +=
+					'<p class="buttonbar"><button name="close" class="autofocus">Close</button></p>';
 			}
-			this.$el.css('max-width', 760).html(buf);
+			this.$el.css("max-width", 760).html(buf);
 		},
 		rulesTimeout: function () {
-			this.$('button')[0].disabled = false;
-			this.$('.overlay-warn').remove();
-		}
-	});
-
+			this.$("button")[0].disabled = false;
+			this.$(".overlay-warn").remove();
+		},
+	}));
 }).call(this, jQuery);

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["src/", "js/"],
+  "watch": ["src/", "js/", "config/"],
   "ext": "js,ts,css,html,json,tsx,jsx",
   "verbose": true,
   "ignore": [
@@ -12,6 +12,7 @@
     "js/client-main.js",
     "js/client-main.js.map",
     "js/panel*.js",
-    "js/replay-embed.js"
+    "js/replay-embed.js",
+    "config/config.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/jquery": "^3.5.3",
     "@types/mocha": "^5.2.6",
+    "command-line-args": "^6.0.0",
     "eslint": "^5.16.0",
     "mocha": "^6.0.2",
     "nodemon": "^3.1.4",

--- a/start_browsers.js
+++ b/start_browsers.js
@@ -1,0 +1,96 @@
+/**
+ * This script is a workaround for a limitation of VSCode's builtin browser debugger that seems to only ever spawn one instance of a given url at a time.
+ * Instead, we use this script to call chrome's cli manually and open up two tabs with different username query params specified.
+ * This eases the process of creating a live battle testing environment by opening two tabs, each with a diff username preconfigured.
+ * Ideally, we may also add some dev configuration to automatically initiate a battle challenge between the two tabs.
+ */
+var { spawn } = require("child_process");
+var fs = require("fs");
+var path = require("path");
+var commandLineArgs = require("command-line-args");
+
+async function parseCommandLine() {
+	var x86Path = path.join(
+		"C:",
+		"Program Files (x86)",
+		"Google",
+		"Chrome",
+		"Application",
+		"chrome.exe"
+	);
+	var x64Path = path.join(
+		"C:",
+		"Program Files",
+		"Google",
+		"Chrome",
+		"Application",
+		"chrome.exe"
+	);
+	var defaultBrowser;
+
+	if (fs.existsSync(x86Path)) {
+		defaultBrowser = x86Path;
+	} else if (fs.existsSync(x64Path)) {
+		defaultBrowser = x64Path;
+
+		var params = [
+			{
+				name: "chromepath",
+				type: String | undefined,
+				defaultOption: true,
+				defaultValue: defaultBrowser,
+			},
+			{ name: "user1", type: String, defaultValue: "user123456" },
+			{ name: "user2", type: String, defaultValue: "user7654321" },
+		];
+
+		return commandLineArgs(params);
+	}
+}
+
+async function pipeOutput(child) {
+	return new Promise((res, rej) => {
+		//spit stdout to screen
+		child.stdout.on("data", function (data) {
+			process.stdout.write(data.toString());
+		});
+
+		//spit stderr to screen
+		child.stderr.on("data", function (data) {
+			process.stdout.write(data.toString());
+		});
+
+		child.on("close", function (code) {
+			res(code);
+		});
+	});
+}
+
+async function main() {
+	console.debug(
+		"starting showdown browser tabs for two player battle testing"
+	);
+	var args = await parseCommandLine();
+
+	if (args.chromepath == null) {
+		throw new Error(
+			"Could not locate chrome executable on your system, are you sure it's installed? If so, try providing the full path to chrome.exe as the first argument to the command."
+		);
+	}
+
+	var user1Url = `http://localhost:8080/testclient.html?~~localhost:8000&username=${args.user1}`;
+	var user2Url = `http://localhost:8080/testclient.html?~~localhost:8000&username=${args.user2}`;
+
+	console.debug(
+		`using chrome binary at ${args.chromepath}, user1 url: ${user1Url}, user2 url: ${user2Url}`
+	);
+	await pipeOutput(
+		spawn(args.chromepath, [
+			user1Url,
+			user2Url,
+			"--remote-debugging-port=9200",
+		])
+	);
+}
+
+main().then(() => process.exit(0));

--- a/testclient.html
+++ b/testclient.html
@@ -124,6 +124,8 @@
 		<script src="js/search.js"></script>
 
 		<script src="data/aliases.js" async="async" onerror="loadRemoteData(this.src)"></script>
+		<!-- Order matters here as our dev username bootstrapper requires jQuery and the app.user model to be defined. -->
+		<script src="config/er-config.js"></script>
 
 		<script>
 			window.onload = () => {


### PR DESCRIPTION
Adding new VSCode launch configuration that starts two chrome browser tabs, each prepopulated with a valid username (player11112222 and player88889999) which easily sets up a battle testing environment.
The new launch config is called [DEV] Battle Debugging.
Note that this variant launches the chrome browser externally to VSCode and then attaches via the remote-debugging-port. I created a node js script to do this and it tries to find chrome installed on your machine at either C:/Program Files (x86)/ or C:/Program Files/ (so only supports windows for now, someone could add mac/linux support to the script relatively easily if needed). You can also specify an absolute path to the chrome binary via a command line argument to the script, but the VSCode task doesn't support specifying that.