### PR TITLE
Handling bleed edge cases and incorrect status indicators

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -2778,8 +2778,8 @@ export class PokemonSprite extends Sprite {
 			status += '<span class="par">PAR</span> ';
 		} else if (pokemon.status === 'frz') {
 			status += '<span class="frz">FRZ</span> ';
-		} else if (pokemon.status === 'bleed') {
-			status += '<span class="bleed">BLD</span>';
+		} else if (pokemon.status === 'bld') {
+			status += '<span class="bld">BLD</span>';
 		}
 		if (pokemon.terastallized) {
 			status += `<img src="${Dex.resourcePrefix}sprites/types/${encodeURIComponent(pokemon.terastallized)}.png" alt="${pokemon.terastallized}" class="pixelated" /> `;

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -1045,7 +1045,7 @@ type NatureName = 'Adamant' | 'Bashful' | 'Bold' | 'Brave' | 'Calm' | 'Careful' 
 type StatNameExceptHP = 'atk' | 'def' | 'spa' | 'spd' | 'spe';
 type TypeName = 'Normal' | 'Fighting' | 'Flying' | 'Poison' | 'Ground' | 'Rock' | 'Bug' | 'Ghost' | 'Steel' |
 	'Fire' | 'Water' | 'Grass' | 'Electric' | 'Psychic' | 'Ice' | 'Dragon' | 'Dark' | 'Fairy' | '???';
-type StatusName = 'par' | 'psn' | 'frz' | 'slp' | 'brn' | 'bleed';
+type StatusName = 'par' | 'psn' | 'frz' | 'slp' | 'brn' | 'bld';
 type BoostStatName = 'atk' | 'def' | 'spa' | 'spd' | 'spe' | 'evasion' | 'accuracy' | 'spc';
 type GenderName = 'M' | 'F' | 'N';
 

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3218,6 +3218,8 @@ export class Battle {
 			output.status = '';
 		} else if (status === 'par' || status === 'brn' || status === 'slp' || status === 'frz' || status === 'tox') {
 			output.status = status;
+		} else if (status === 'bld') {
+			output.status = "bld";
 		} else if (status === 'psn' && output.status !== 'tox') {
 			output.status = status;
 		} else if (status === 'fnt') {

--- a/style/client.css
+++ b/style/client.css
@@ -2090,7 +2090,7 @@ a.ilink.yours {
 /**
 * This controls the display of the new bleed status indicator on the client interface status bar.
 */
-.status .bleed {
+.status .bleed, .status.bleed {
 	background: #920c04;
 	border-color: #260301;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -2090,7 +2090,7 @@ a.ilink.yours {
 /**
 * This controls the display of the new bleed status indicator on the client interface status bar.
 */
-.status .bleed, .status.bleed {
+.status .bld, .status.bld {
 	background: #920c04;
 	border-color: #260301;
 }

--- a/style/client2.css
+++ b/style/client2.css
@@ -1683,7 +1683,7 @@ a.ilink.yours {
 .status.frz {
 	background: #009AA4;
 }
-.status .bleed {
+.status .bld {
 	background: #FF5733;
 	border-color: #260301;
 }


### PR DESCRIPTION
Needed to handle all the healing moves within onTryHeal instead of preventing the move entirely. The following edge cases were handled and tested:

- Regenerator + Natural Cure
- Wish (cures bleed on 2nd turn)
- Any status move or healing move that has 0 base power (pollen puff was tested)
- Healing Wish
- Synthesis
- Soft-boiled
- Heal Pulse
- Jungle Healing