### PR TITLE
Ability Batch #2

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -1421,7 +1421,7 @@ class BattleMoveSearch extends BattleTypedSearch<'move'> {
 		case 'refresh':
 			return !moves.includes('aromatherapy') && !moves.includes('healbell');
 		case 'risingvoltage':
-			return abilityid === 'electricsurge' || abilityid === 'hadronengine';
+			return abilityid === 'electrosurge' || abilityid === 'hadronengine';
 		case 'rocktomb':
 			return abilityid === 'technician';
 		case 'selfdestruct':

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3059,6 +3059,7 @@ export class Battle {
 			let fromeffect = Dex.getEffect(kwArgs.from);
 			this.activateAbility(poke, fromeffect);
 			let minTimeLeft = 5;
+
 			let maxTimeLeft = 0;
 			if (effect.id.endsWith('terrain')) {
 				for (let i = this.pseudoWeather.length - 1; i >= 0; i--) {
@@ -3071,6 +3072,10 @@ export class Battle {
 				if (this.gen > 6) maxTimeLeft = 8;
 			}
 			if (kwArgs.persistent) minTimeLeft += 2;
+			/// Update the trick room duration display when the ability twisted dimension activates as it will only last 3 turns in this case.
+			if (kwArgs.twistdimension) {
+				minTimeLeft -= 2;
+			}
 			this.addPseudoWeather(effect.name, minTimeLeft, maxTimeLeft);
 
 			switch (effect.id) {


### PR DESCRIPTION
Validated the following previously implemented abilities for changes from 1.6 -> 2.1:
- soul-heart
- electro-surge (renamed from electric surge)
- wandering spirit
- curious medicine
- dragon's maw
- chilling neigh
- as one
- let's roll
- twist. dimension (updated client to check for this ability and properly indicate the duration of only 3 turns)
- bad company
- king's wrath
- queen's wrath
- angel's wrath (validated no move effects changed from 1.6)
- iron fist (modifier updated to 1.3x)
- striker (modifier updated to 1.3x)

Added the following new abilities:
- fairy tale
- kunoichi's blade (untested, no pokemon have this ability yet)
- combat specialist
- jungle's guard
- hunter's horn