### PR TITLE
No [Gen #] display on formats

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -1241,7 +1241,7 @@
 					bufs[curBuf] += '<li><h3>' + BattleLog.escapeHTML(curSection) + '</li>';
 				}
 				var formatName = BattleLog.escapeFormat(format.id);
-				if (formatName.charAt(0) !== '[') formatName = '[Gen 6] ' + formatName;
+				if (formatName.charAt(0) !== '[') formatName = formatName;
 				formatName = formatName.replace('[Gen 8 ', '[');
 				formatName = formatName.replace('[Gen 9] ', '');
 				formatName = formatName.replace('[Gen 7 ', '[');

--- a/js/client.js
+++ b/js/client.js
@@ -1688,7 +1688,7 @@ function toId() {
 					if (isTeambuilderFormat) {
 						teambuilderFormatName = name;
 						if (id.slice(0, 3) !== "gen") {
-							teambuilderFormatName = "[Gen 6] " + name;
+							teambuilderFormatName = name;
 						}
 						var parenPos = teambuilderFormatName.indexOf("(");
 						if (parenPos > 0 && name.slice(-1) === ")") {

--- a/src/panel-mainmenu.tsx
+++ b/src/panel-mainmenu.tsx
@@ -148,7 +148,7 @@ class MainMenuRoom extends PSRoom {
 				if (isTeambuilderFormat) {
 					teambuilderFormatName = name;
 					if (id.slice(0, 3) !== 'gen') {
-						teambuilderFormatName = '[Gen 6] ' + name;
+						teambuilderFormatName = name;
 					}
 					let parenPos = teambuilderFormatName.indexOf('(');
 					if (parenPos > 0 && name.slice(-1) === ')') {


### PR DESCRIPTION
There was some hardcoded checks on the client to add [Gen 6] for a format if no gen was specied.